### PR TITLE
DM-27663: Update ts_observatory_control other packages to stop using Rotator application topic

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "Formatting Python code with black"
-black .
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-yaml
+        exclude: conda/meta.yaml
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,23 @@
 Version History
 ###############
 
+v0.5.1
+======
+
+Changes:
+
+* Stop using topic ``application`` from ``MTRotator`` which is marked for deprecation.
+* Remove git commit hooks and implement pre-commit.
+* Use pytest-black in unit test.
+* Implement Jenkins shared library for conda build.
+
+Requirements:
+
+* ts_salobj >= 5.6.0
+* ts_xml >= 7.0.0
+* ts_idl >= 2.0.0
+* IDL files for all components, e.g. built with ``make_idl_files.py``
+
 v0.5.0
 ======
 
@@ -17,7 +34,7 @@ Requirements:
 
 * ts_salobj >= 5.6.0
 * ts_xml >= 7.0.0
-* ts_idl >= 1.3.0
+* ts_idl >= 2.0.0
 * IDL files for all components, e.g. built with ``make_idl_files.py``
 
 v0.4.2

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -313,11 +313,13 @@ class MTCS(BaseTCS):
                 )
 
             if _check.mtrotator:
-                rotator = await self.rem.mtrotator.tel_application.next(
+                rotation_data = await self.rem.mtrotator.tel_rotation.next(
                     flush=True, timeout=self.fast_timeout
                 )
-                distance_rot = salobj.angle_diff(rotator.demand, rotator.position)
-                status += f"[Rot]: {rotator.position:+08.3f}[{distance_rot.deg:+6.1f}] "
+                distance_rot = salobj.angle_diff(
+                    rotation_data.demandPosition, rotation_data.actualPosition
+                )
+                status += f"[Rot]: {rotation_data.demandPosition:+08.3f}[{distance_rot.deg:+6.1f}] "
 
             if _check.mtdome:
                 dome_az = await self.rem.mtdome.tel_azimuth.next(
@@ -558,10 +560,10 @@ class MTCS(BaseTCS):
 
         el = await self.rem.mtmount.tel_Elevation.aget(timeout=self.fast_timeout)
 
-        rotator = await self.rem.mtrotator.tel_application.aget(
+        rotation_data = await self.rem.mtrotator.tel_rotation.aget(
             timeout=self.fast_timeout
         )
-        angle = el.Elevation_Angle_Actual - rotator.position
+        angle = el.Elevation_Angle_Actual - rotation_data.actualPosition
 
         return angle
 
@@ -651,7 +653,7 @@ class MTCS(BaseTCS):
                     "timeAndDate",
                     "target",
                 ],
-                mtrotator=["application"],
+                mtrotator=["rotation"],
                 mtmount=["Azimuth", "Elevation", "axesInPosition", "inPosition"],
                 mtdome=["azimuth", "lightWindScreen"],
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ exclude =
   tests/.tests
 
 [tool:pytest]
-addopts = --flake8
+addopts = --flake8 --black
 flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816 W503
 
 [metadata]

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -114,21 +114,21 @@ class TestMTCS(RemoteGroupTestCase, asynctest.TestCase):
                 slew_timeout=SLEW_TIMEOUT,
             )
 
-            az_rec = await self.mtcs.rem.mtmount.tel_Azimuth.next(
+            az_data = await self.mtcs.rem.mtmount.tel_Azimuth.next(
                 flush=True, timeout=HB_TIMEOUT
             )
 
-            el_rec = await self.mtcs.rem.mtmount.tel_Elevation.next(
+            el_data = await self.mtcs.rem.mtmount.tel_Elevation.next(
                 flush=True, timeout=HB_TIMEOUT
             )
 
-            rot_rec = await self.mtcs.rem.mtrotator.tel_application.next(
+            rot_data = await self.mtcs.rem.mtrotator.tel_rotation.next(
                 flush=True, timeout=HB_TIMEOUT
             )
 
-            self.assertEqual(az_rec.Azimuth_Angle_Set, az_set)
-            self.assertEqual(el_rec.Elevation_Angle_Set, el_set)
-            self.assertEqual(rot_rec.demand, rot_set)
+            self.assertEqual(az_data.Azimuth_Angle_Set, az_set)
+            self.assertEqual(el_data.Elevation_Angle_Set, el_set)
+            self.assertEqual(rot_data.demandPosition, rot_set)
 
     async def test_slew_all(self):
 


### PR DESCRIPTION
Remove usage of deprecated rotator application topic in favor of rotation.
Remove pre-commit hook and add pre-commit configuration.
Add pytest-back.