### PR TITLE
DM-28187: Update ts_observatory_control and ts_standardscript to remove NewMTMount

### DIFF
--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -359,9 +359,13 @@ class ATCS(BaseTCS):
         else:
             # TODO: DM-24525 remove hard coded 8 when real ATMCS is fixed.
             while at_mount_state.state not in (8, ATMCS.AtMountState.TRACKINGDISABLED):
-                self.log.debug(
-                    f"Tracking state: {ATMCS.AtMountState(at_mount_state.state)!r}."
+                tracking_state = (
+                    ATMCS.AtMountState(at_mount_state.state)
+                    if at_mount_state.state in [value for value in ATMCS.AtMountState]
+                    else f"Unknown({at_mount_state.state})"
                 )
+
+                self.log.debug(f"Tracking state: {tracking_state!r}.")
                 at_mount_state = await self.rem.atmcs.evt_atMountState.next(
                     flush=False, timeout=self.long_timeout
                 )

--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -359,13 +359,12 @@ class ATCS(BaseTCS):
         else:
             # TODO: DM-24525 remove hard coded 8 when real ATMCS is fixed.
             while at_mount_state.state not in (8, ATMCS.AtMountState.TRACKINGDISABLED):
-                tracking_state = (
-                    ATMCS.AtMountState(at_mount_state.state)
-                    if at_mount_state.state in [value for value in ATMCS.AtMountState]
-                    else f"Unknown({at_mount_state.state})"
-                )
-
-                self.log.debug(f"Tracking state: {tracking_state!r}.")
+                try:
+                    self.log.debug(
+                        f"Tracking state: {ATMCS.AtMountState(at_mount_state.state)!r}"
+                    )
+                except ValueError:
+                    self.log.warning(f"Unknown tracking state: {at_mount_state.state}")
                 at_mount_state = await self.rem.atmcs.evt_atMountState.next(
                     flush=False, timeout=self.long_timeout
                 )

--- a/python/lsst/ts/observatory/control/mock/mtcs_mock.py
+++ b/python/lsst/ts/observatory/control/mock/mtcs_mock.py
@@ -51,7 +51,6 @@ class MTCSMock(BaseGroupMock):
 
         super().__init__(
             components=[
-                "NewMTMount",
                 "MTMount",
                 "MTPtg",
                 "MTAOS",
@@ -63,7 +62,6 @@ class MTCSMock(BaseGroupMock):
                 "MTDome",
                 "MTDomeTrajectory",
             ],
-            output_only=["MTMount"],
         )
 
         self.location = EarthLocation.from_geodetic(
@@ -79,14 +77,14 @@ class MTCSMock(BaseGroupMock):
         self.controllers.mtptg.cmd_azElTarget.callback = self.azel_target_callback
         self.controllers.mtptg.cmd_raDecTarget.callback = self.radec_target_callback
 
-        self.controllers.mtmount.tel_Azimuth.set(Azimuth_Angle_Set=0.0)
-        self.controllers.mtmount.tel_Elevation.set(Elevation_Angle_Set=80.0)
+        self.controllers.mtmount.tel_azimuth.set(angleSet=0.0)
+        self.controllers.mtmount.tel_elevation.set(angleSet=80.0)
 
     async def mtptg_stop_tracking_callback(self, data):
 
         self.tracking = False
         self.acting = False
-        self.controllers.newmtmount.evt_axesInPosition.set_put(
+        self.controllers.mtmount.evt_axesInPosition.set_put(
             elevation=False, azimuth=False
         )
         self.controllers.mtrotator.evt_inPosition.set_put(inPosition=False)
@@ -105,15 +103,15 @@ class MTCSMock(BaseGroupMock):
 
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
-        self.controllers.newmtmount.evt_target.set(
+        self.controllers.mtmount.evt_target.set(
             elevation=data.elDegs, azimuth=data.azDegs, trackId=data.trackId,
         )
 
         self.acting = True
 
-        self.controllers.mtmount.tel_Azimuth.set(Azimuth_Angle_Set=data.azDegs)
+        self.controllers.mtmount.tel_azimuth.set(angleSet=data.azDegs)
 
-        self.controllers.mtmount.tel_Elevation.set(Elevation_Angle_Set=data.elDegs)
+        self.controllers.mtmount.tel_elevation.set(angleSet=data.elDegs)
 
         self.controllers.mtrotator.tel_rotation.set(demandPosition=data.rotPA)
 
@@ -133,7 +131,7 @@ class MTCSMock(BaseGroupMock):
             targetName=data.targetName,
         )
 
-        self.controllers.newmtmount.evt_target.set(trackId=data.trackId)
+        self.controllers.mtmount.evt_target.set(trackId=data.trackId)
 
         self.tracking = True
         self.acting = True
@@ -151,36 +149,32 @@ class MTCSMock(BaseGroupMock):
 
         while self.run_telemetry_loop:
             if (
-                self.controllers.newmtmount.evt_summaryState.data.summaryState
+                self.controllers.mtmount.evt_summaryState.data.summaryState
                 == salobj.State.ENABLED
             ):
 
                 # Safely initilize data
-                if not self.controllers.mtmount.tel_Azimuth.has_data:
-                    self.controllers.mtmount.tel_Azimuth.set(
-                        Azimuth_Angle_Set=0.0, Azimuth_Angle_Actual=0.0
+                if not self.controllers.mtmount.tel_azimuth.has_data:
+                    self.controllers.mtmount.tel_azimuth.set(
+                        angleSet=0.0, angleActual=0.0
                     )
 
-                if not self.controllers.mtmount.tel_Elevation.has_data:
-                    self.controllers.mtmount.tel_Elevation.set(
-                        Elevation_Angle_Set=0.0, Elevation_Angle_Actual=0.0
+                if not self.controllers.mtmount.tel_elevation.has_data:
+                    self.controllers.mtmount.tel_elevation.set(
+                        angleSet=0.0, angleActual=0.0
                     )
 
-                if not self.controllers.newmtmount.evt_target.has_data:
-                    self.controllers.newmtmount.evt_target.set()
+                if not self.controllers.mtmount.evt_target.has_data:
+                    self.controllers.mtmount.evt_target.set()
 
                 az_induced_error = np.random.normal(0.0, 1e-7)
                 el_induced_error = np.random.normal(0.0, 1e-7)
 
-                az_set = self.controllers.mtmount.tel_Azimuth.data.Azimuth_Angle_Set
-                el_set = self.controllers.mtmount.tel_Elevation.data.Elevation_Angle_Set
+                az_set = self.controllers.mtmount.tel_azimuth.data.angleSet
+                el_set = self.controllers.mtmount.tel_elevation.data.angleSet
 
-                az_actual = (
-                    self.controllers.mtmount.tel_Azimuth.data.Azimuth_Angle_Actual
-                )
-                el_actual = (
-                    self.controllers.mtmount.tel_Elevation.data.Elevation_Angle_Actual
-                )
+                az_actual = self.controllers.mtmount.tel_azimuth.data.angleActual
+                el_actual = self.controllers.mtmount.tel_elevation.data.angleActual
 
                 az_dif = salobj.angle_diff(az_set, az_actual)
                 el_dif = salobj.angle_diff(el_set, el_actual)
@@ -188,20 +182,18 @@ class MTCSMock(BaseGroupMock):
                 in_position_azimuth = np.abs(az_dif) < 1e-1 * u.deg
 
                 if self.acting:
-                    self.controllers.newmtmount.evt_axesInPosition.set_put(
+                    self.controllers.mtmount.evt_axesInPosition.set_put(
                         elevation=in_position_elevation, azimuth=in_position_azimuth
                     )
 
-                self.controllers.mtmount.tel_Azimuth.set_put(
-                    Azimuth_Angle_Actual=az_actual + az_induced_error + az_dif.deg / 1.1
+                self.controllers.mtmount.tel_azimuth.set_put(
+                    angleActual=az_actual + az_induced_error + az_dif.deg / 1.1
                 )
-                self.controllers.mtmount.tel_Elevation.set_put(
-                    Elevation_Angle_Actual=el_actual
-                    + el_induced_error
-                    + el_dif.deg / 1.1
+                self.controllers.mtmount.tel_elevation.set_put(
+                    angleActual=el_actual + el_induced_error + el_dif.deg / 1.1
                 )
 
-                self.controllers.newmtmount.evt_target.put()
+                self.controllers.mtmount.evt_target.put()
 
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -264,12 +256,8 @@ class MTCSMock(BaseGroupMock):
                     self.controllers.mtdometrajectory.evt_summaryState.data.summaryState
                     == salobj.State.ENABLED
                 ):
-                    dome_az_set = (
-                        self.controllers.mtmount.tel_Azimuth.data.Azimuth_Angle_Set
-                    )
-                    dome_el_set = (
-                        self.controllers.mtmount.tel_Elevation.data.Elevation_Angle_Set
-                    )
+                    dome_az_set = self.controllers.mtmount.tel_azimuth.data.angleSet
+                    dome_el_set = self.controllers.mtmount.tel_elevation.data.angleSet
 
                 self.controllers.mtdome.tel_azimuth.set(
                     positionCommanded=dome_az_set,
@@ -336,19 +324,15 @@ class MTCSMock(BaseGroupMock):
                         elDegs=alt_az.alt.deg,
                     )
 
-                    self.controllers.mtmount.tel_Azimuth.set(
-                        Azimuth_Angle_Set=alt_az.az.deg
-                    )
+                    self.controllers.mtmount.tel_azimuth.set(angleSet=alt_az.az.deg)
 
-                    self.controllers.mtmount.tel_Elevation.set(
-                        Elevation_Angle_Set=alt_az.alt.deg
-                    )
+                    self.controllers.mtmount.tel_elevation.set(angleSet=alt_az.alt.deg)
 
                     self.controllers.mtrotator.tel_rotation.set(
                         demandPosition=self.controllers.mtptg.evt_currentTarget.data.rotPA
                     )
 
-                    self.controllers.newmtmount.evt_target.set(
+                    self.controllers.mtmount.evt_target.set(
                         elevation=alt_az.alt.deg, azimuth=alt_az.az.deg,
                     )
 

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -475,16 +475,21 @@ class RemoteGroup:
 
         Raises
         ------
-        asyncio.TimeoutError
+        RuntimeError
             If the component does not send heartbeats in `self.fast_timeout`
             seconds.
 
         """
 
         while True:
-            await getattr(self.rem, component).evt_heartbeat.next(
-                flush=True, timeout=self.fast_timeout
-            )
+            try:
+                await getattr(self.rem, component).evt_heartbeat.next(
+                    flush=True, timeout=self.fast_timeout
+                )
+            except asyncio.TimeoutError:
+                raise RuntimeError(
+                    f"No heartbeat from {component} received in {self.fast_timeout}s."
+                )
 
     async def inspect_settings(self, components_attr=None):
         """Return available settings.

--- a/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
+++ b/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
@@ -146,6 +146,8 @@ class RemoteGroupTestCase(metaclass=abc.ABCMeta):
             print(f"wait for {description}")
         try:
             result = await asyncio.wait_for(coro, timeout=timeout)
+        except asyncio.CancelledError:
+            print(f"{description}: Cancelled error.")
         except asyncio.TimeoutError:
             dt = time.monotonic() - t0
             print(f"{description} timed out after {dt:0.1f} seconds")

--- a/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
+++ b/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
@@ -146,8 +146,6 @@ class RemoteGroupTestCase(metaclass=abc.ABCMeta):
             print(f"wait for {description}")
         try:
             result = await asyncio.wait_for(coro, timeout=timeout)
-        except asyncio.CancelledError:
-            print(f"{description}: Cancelled error.")
         except asyncio.TimeoutError:
             dt = time.monotonic() - t0
             print(f"{description} timed out after {dt:0.1f} seconds")

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -114,11 +114,11 @@ class TestMTCS(RemoteGroupTestCase, asynctest.TestCase):
                 slew_timeout=SLEW_TIMEOUT,
             )
 
-            az_data = await self.mtcs.rem.mtmount.tel_Azimuth.next(
+            az_data = await self.mtcs.rem.mtmount.tel_azimuth.next(
                 flush=True, timeout=HB_TIMEOUT
             )
 
-            el_data = await self.mtcs.rem.mtmount.tel_Elevation.next(
+            el_data = await self.mtcs.rem.mtmount.tel_elevation.next(
                 flush=True, timeout=HB_TIMEOUT
             )
 
@@ -126,8 +126,8 @@ class TestMTCS(RemoteGroupTestCase, asynctest.TestCase):
                 flush=True, timeout=HB_TIMEOUT
             )
 
-            self.assertEqual(az_data.Azimuth_Angle_Set, az_set)
-            self.assertEqual(el_data.Elevation_Angle_Set, el_set)
+            self.assertEqual(az_data.angleSet, az_set)
+            self.assertEqual(el_data.angleSet, el_set)
             self.assertEqual(rot_data.demandPosition, rot_set)
 
     async def test_slew_all(self):


### PR DESCRIPTION
Implement changes required by xml 7.1:
	* Removes NewMTMount (replaced by MTMount)
	* Update MTMount topics names and attributes.
Improve error messages when heartbeat monitor fails.
Improve error messages when slew/track target commands fails.