### PR TITLE
DM-28417: Support AT observing run 2020/01

### DIFF
--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -359,9 +359,12 @@ class ATCS(BaseTCS):
         else:
             # TODO: DM-24525 remove hard coded 8 when real ATMCS is fixed.
             while at_mount_state.state not in (8, ATMCS.AtMountState.TRACKINGDISABLED):
-                self.log.debug(
-                    f"Tracking state: {ATMCS.AtMountState(at_mount_state.state)!r}."
-                )
+                try:
+                    self.log.debug(
+                        f"Tracking state: {ATMCS.AtMountState(at_mount_state.state)!r}."
+                    )
+                except ValueError:
+                    self.log.debug(f"Unknown tracking state: {at_mount_state.state}.")
                 at_mount_state = await self.rem.atmcs.evt_atMountState.next(
                     flush=False, timeout=self.long_timeout
                 )

--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -992,9 +992,16 @@ class ATCS(BaseTCS):
     async def offset_done(self):
         """Wait for offset events.
         """
-        await self.rem.atmcs.evt_allAxesInPosition.next(
-            flush=False, timeout=self.tel_settle_time
-        )
+        while True:
+            in_position = await self.rem.atmcs.evt_allAxesInPosition.next(
+                flush=False, timeout=self.tel_settle_time
+            )
+
+            if in_position.inPosition:
+                self.log.debug("All axes in position.")
+                return in_position.inPosition
+            else:
+                self.log.debug("Telescope not in position.")
 
     async def wait_for_inposition(
         self, timeout, cmd_ack=None, wait_settle=True, check=None


### PR DESCRIPTION
Fix error with atcs.stop_tracking.
Make some improvement to ATCS open/close dome methods. 