### PR TITLE
DM-28995 Support summit activities

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -12,7 +12,7 @@ v0.7.1
 Changes:
 
   * Add workaround to edge condition while homing the ATDome.
-    If the dome is pressing the home switch and we send a home command, it will simply register the dome as homed and won't send any event to indicate the activity is complete.
+    Now if the dome is pressing the home switch and we send a home command, it will simply register the dome as homed and won't send any event to indicate the activity is complete.
   * Add method to reset all offsets in base_tcs.
   * Add set_rem_loglevel method in RemoteGroup, that allows users to set the log level for the remotes loggers.
   * Fix "restore check" feature in prepare for flats.

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -11,6 +11,30 @@ v0.7.1
 
 Changes:
 
+  * Add workaround to edge condition while homing the ATDome.
+    If the dome is pressing the home switch and we send a home command, it will simply register the dome as homed and won't send any event to indicate the activity is complete.
+  * Add method to reset all offsets in base_tcs.
+  * Add set_rem_loglevel method in RemoteGroup, that allows users to set the log level for the remotes loggers.
+  * Fix "restore check" feature in prepare for flats.
+  * Fix direction of PhysicalSky rotator strategy.
+  * Update ATCS to support specifying rotator park position and flat field position.
+    When using point_azel to slew the telescope for a safe position, use the current nasmyth position.
+  * Fix setting rotFrame in xml7/8 compatibility mode.
+  * Update ronchi170lpmm sweet spot.
+  * Support differential ra/dec tracking in BaseTCS.
+
+Requirements:
+
+  * ts_salobj >= 5.6.0
+  * ts_xml >= 7.1.0
+  * ts_idl >= 2.0.0
+  * IDL files for all components, e.g. built with ``make_idl_files.py``
+
+v0.7.1
+======
+
+Changes:
+
   * Implement xml 7/8 compatibility.
   * Fix `add_point_data` in BaseTCS.
   * Fix timeout in opening/closing the dome.

--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -929,13 +929,6 @@ class ATCS(BaseTCS):
             # before opening the mirror cover.
             tel_pos = await self.next_telescope_position(timeout=self.fast_timeout)
 
-            try:
-                nasmyth = await self.rem.atmcs.tel_mount_Nasmyth_Encoders.aget(
-                    timeout=self.fast_timeout
-                )
-            except asyncio.TimeoutError:
-                raise RuntimeError("Cannot determine nasmyth position.")
-
             nasmyth_angle = await self.get_selected_nasmyth_angle()
 
             if tel_pos.elevationCalculatedAngle[-1] < self.tel_el_operate_pneumatics:
@@ -1623,6 +1616,7 @@ class ATCS(BaseTCS):
                     "pointNewFile",
                     "pointAddData",
                     "timeAndDate",
+                    "focusNameSelected",
                 ],
                 ataos=["enableCorrection", "disableCorrection", "applyFocusOffset"],
                 atpneumatics=[
@@ -1672,6 +1666,7 @@ class ATCS(BaseTCS):
                     "pointNewFile",
                     "pointAddData",
                     "timeAndDate",
+                    "focusNameSelected",
                 ],
                 atdome=["stopMotion", "shutterInPosition"],
                 athexapod=["positionUpdate"],
@@ -1747,7 +1742,12 @@ class ATCS(BaseTCS):
                     "position",
                     "mount_Nasmyth_Encoders",
                 ],
-                atptg=["azElTarget", "moveAzimuth", "stopTracking"],
+                atptg=[
+                    "azElTarget",
+                    "moveAzimuth",
+                    "stopTracking",
+                    "focusNameSelected",
+                ],
                 atdome=[
                     "stopMotion",
                     "moveShutterMainDoor",
@@ -1790,7 +1790,12 @@ class ATCS(BaseTCS):
                     "position",
                     "mount_Nasmyth_Encoders",
                 ],
-                atptg=["azElTarget", "moveAzimuth", "stopTracking"],
+                atptg=[
+                    "azElTarget",
+                    "moveAzimuth",
+                    "stopTracking",
+                    "focusNameSelected",
+                ],
                 atdome=["stopMotion", "homeAzimuth"],
                 atpneumatics=[
                     "openM1Cover",
@@ -1812,7 +1817,7 @@ class ATCS(BaseTCS):
                     "position",
                     "mount_Nasmyth_Encoders",
                 ],
-                atptg=["timeAndDate", "poriginOffset"],
+                atptg=["timeAndDate", "poriginOffset", "focusNameSelected"],
                 atpneumatics=[
                     "m1SetPressure",
                     "m2SetPressure",

--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -317,13 +317,14 @@ class ATCS(BaseTCS):
 
         # Creates a copy of check so it can modify it freely to control what
         # needs to be verified at each stage of the process.
-        _check = copy.copy(self.check) if check is None else copy.copy(check)
+        check_bckup = copy.copy(self.check) if check is None else copy.copy(check)
+        check_ops = copy.copy(self.check) if check is None else copy.copy(check)
 
         await salobj.set_summary_state(self.rem.atdometrajectory, salobj.State.DISABLED)
 
         await self.open_m1_cover()
 
-        _check.atdometrajectory = False
+        check_ops.atdometrajectory = False
 
         try:
             await self.point_azel(
@@ -339,8 +340,10 @@ class ATCS(BaseTCS):
             except asyncio.TimeoutError:
                 self.log.debug("Timeout in stopping tracking. Continuing.")
 
-            await self.slew_dome_to(self.dome_flat_az, _check)
+            await self.slew_dome_to(self.dome_flat_az, check_ops)
         finally:
+            # recover check
+            self.check = copy.copy(check_bckup)
             await salobj.set_summary_state(
                 self.rem.atdometrajectory, salobj.State.ENABLED
             )

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -149,7 +149,13 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
         raise NotImplementedError("Start tracking not implemented yet.")
 
     async def slew_object(
-        self, name, rot=0.0, rot_type=RotType.SkyAuto, slew_timeout=240.0,
+        self,
+        name,
+        rot=0.0,
+        rot_type=RotType.SkyAuto,
+        dra=0.0,
+        ddec=0.0,
+        slew_timeout=240.0,
     ):
         """Slew to an object name.
 
@@ -168,6 +174,10 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             Default is `SkyAuto`, the rotator is positioned with respect to the
             North axis and is automacally wrapped if outside the limit. See
             `RotType` for more options.
+        dra : `float`
+            Differential Track Rate in RA (arcsec/second). Default is 0.
+        ddec : `float`
+            Differential Track Rate in Dec (arcsec/second). Default is 0.
         slew_timeout : `float`
             Timeout for the slew command (second).
 
@@ -194,6 +204,8 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             rot=rot,
             rot_type=rot_type,
             target_name=name,
+            dra=dra,
+            ddec=ddec,
             slew_timeout=slew_timeout,
         )
 
@@ -204,6 +216,8 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
         rot=0.0,
         rot_type=RotType.SkyAuto,
         target_name="slew_icrs",
+        dra=0.0,
+        ddec=0.0,
         slew_timeout=240.0,
         stop_before_slew=True,
         wait_settle=True,
@@ -233,6 +247,10 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             `RotType` for more options.
         target_name :  `str`
             Target name.
+        dra : `float`
+            Differential Track Rate in RA (arcsec/second). Default is 0.
+        ddec : `float`
+            Differential Track Rate in Dec (arcsec/second). Default is 0.
         slew_timeout : `float`
             Timeout for the slew command (second). Default is 240s.
         stop_before_slew : `bool`
@@ -351,8 +369,8 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             pmRA=0,
             pmDec=0,
             rv=0,
-            dRA=0,
-            dDec=0,
+            dRA=dra,
+            dDec=ddec,
             rot_frame=rot_frame,
             rot_mode=self.RotMode.FIELD,
             slew_timeout=slew_timeout,

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -683,7 +683,7 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
 
         reset_offsets = []
 
-        if not persistent and not user:
+        if not persistent and not non_persistent:
             raise RuntimeError("Select at least one offset to reset.")
 
         if persistent:

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -469,9 +469,12 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             )
         else:
             # xml 7
+            _rot_frame = rot_frame if rot_frame is not None else self.RotFrame.TARGET
+            self.log.debug(
+                f"xml 7 compatibility mode: rotPA={rotPA}, rotFrame={_rot_frame}"
+            )
             getattr(self.rem, self.ptg_name).cmd_raDecTarget.set(
-                rotPA=rotPA,
-                rotFrame=rot_frame if rot_frame is not None else self.RotFrame.TARGET,
+                rotPA=rotPA, rotFrame=_rot_frame,
             )
             if rot_track_frame is not None:
                 self.log.warning(

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -299,7 +299,7 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             Angle(
                 Angle(180.0, unit=u.deg)
                 + par_angle
-                - rot_angle
+                + rot_angle
                 - (
                     alt_az.alt
                     if self.instrument_focus == InstrumentFocus.Nasmyth

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -661,6 +661,25 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
             )
             await self.offset_azel(az, el, relative)
 
+    async def reset_offsets(self):
+        """Reset all offsets.
+        """
+        self.log.debug("Reseting all offsets.")
+        await asyncio.gather(
+            getattr(self.rem, self.ptg_name).cmd_poriginClear.set_start(
+                num=0, timeout=self.fast_timeout
+            ),
+            getattr(self.rem, self.ptg_name).cmd_poriginClear.set_start(
+                num=1, timeout=self.fast_timeout
+            ),
+            getattr(self.rem, self.ptg_name).cmd_offsetClear.set_start(
+                num=0, timeout=self.fast_timeout
+            ),
+            getattr(self.rem, self.ptg_name).cmd_offsetClear.set_start(
+                num=1, timeout=self.fast_timeout
+            ),
+        )
+
     async def add_point_data(self):
         """ Add current position to a point file. If a file is open it will
         append to that file. If no file is opened it will open a new one.

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -459,6 +459,10 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
         ):
             # xml >8
             getattr(self.rem, self.ptg_name).cmd_raDecTarget.set(
+                ra=ra,
+                declination=dec,
+                targetName=target_name,
+                frame=frame if frame is not None else self.CoordFrame.ICRS,
                 rotAngle=rotPA,
                 rotStartFrame=rot_frame
                 if rot_frame is not None
@@ -466,6 +470,15 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
                 rotTrackFrame=rot_track_frame
                 if rot_track_frame is not None
                 else self.RotFrame.TARGET,
+                epoch=epoch,
+                equinox=equinox,
+                parallax=parallax,
+                pmRA=pmRA,
+                pmDec=pmDec,
+                rv=rv,
+                dRA=dRA,
+                dDec=dDec,
+                rotMode=rot_mode if rot_mode is not None else self.RotMode.FIELD,
             )
         else:
             # xml 7
@@ -474,28 +487,27 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
                 f"xml 7 compatibility mode: rotPA={rotPA}, rotFrame={_rot_frame}"
             )
             getattr(self.rem, self.ptg_name).cmd_raDecTarget.set(
-                rotPA=rotPA, rotFrame=_rot_frame,
+                ra=ra,
+                declination=dec,
+                targetName=target_name,
+                frame=frame if frame is not None else self.CoordFrame.ICRS,
+                rotPA=rotPA,
+                rotFrame=_rot_frame,
+                epoch=epoch,
+                equinox=equinox,
+                parallax=parallax,
+                pmRA=pmRA,
+                pmDec=pmDec,
+                rv=rv,
+                dRA=dRA,
+                dDec=dDec,
+                rotMode=rot_mode if rot_mode is not None else self.RotMode.FIELD,
             )
+
             if rot_track_frame is not None:
                 self.log.warning(
                     f"Recived {rot_track_frame!r}. Rotator tracking frame only available in xml 8 and up."
                 )
-
-        getattr(self.rem, self.ptg_name).cmd_raDecTarget.set(
-            ra=ra,
-            declination=dec,
-            targetName=target_name,
-            frame=frame if frame is not None else self.CoordFrame.ICRS,
-            epoch=epoch,
-            equinox=equinox,
-            parallax=parallax,
-            pmRA=pmRA,
-            pmDec=pmDec,
-            rv=rv,
-            dRA=dRA,
-            dDec=dDec,
-            rotMode=rot_mode if rot_mode is not None else self.RotMode.FIELD,
-        )
 
         try:
             await self._slew_to(

--- a/python/lsst/ts/observatory/control/constants/latiss_constants.py
+++ b/python/lsst/ts/observatory/control/constants/latiss_constants.py
@@ -27,7 +27,7 @@ pixel_scale = 0.09569  # arcsec/pixel
 boresight = PointD(2036.5, 2000.5)  # boreSight on detector (pixels)
 sweet_spots = {  # the sweet spots for the gratings (pixels)
     "ronchi90lpmm": PointD(1780, 1800),
-    "ronchi170lpmm": PointD(1780, 1800),  # estimate added in DM-28818
-    "holo4_003": PointD(1750, 300),   # estimate added in DM-28818
+    "ronchi170lpmm": PointD(1750, 300),  # estimate added in DM-28818
+    "holo4_003": PointD(1750, 300),  # estimate added in DM-28818
     "empty_1": PointD(1780, 1800),
 }

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -646,6 +646,7 @@ class MTCS(BaseTCS):
                     "pointNewFile",
                     "pointAddData",
                     "timeAndDate",
+                    "focusNameSelected",
                 ],
             )
 
@@ -665,6 +666,7 @@ class MTCS(BaseTCS):
                     "pointAddData",
                     "timeAndDate",
                     "target",
+                    "focusNameSelected",
                 ],
                 mtrotator=["rotation", "inPosition"],
                 mtmount=["azimuth", "elevation", "axesInPosition"],
@@ -685,7 +687,7 @@ class MTCS(BaseTCS):
                     "settingVersions",
                     "heartbeat",
                 ],
-                mtptg=["azElTarget", "stopTracking"],
+                mtptg=["azElTarget", "stopTracking", "focusNameSelected"],
             )
 
             usages[self.valid_use_cases.Shutdown] = UsagesResources(
@@ -702,7 +704,7 @@ class MTCS(BaseTCS):
                     "settingVersions",
                     "heartbeat",
                 ],
-                mtptg=["azElTarget", "stopTracking"],
+                mtptg=["azElTarget", "stopTracking", "focusNameSelected"],
             )
 
             usages[self.valid_use_cases.PrepareForFlatfield] = UsagesResources(

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -724,6 +724,20 @@ class RemoteGroup:
 
         await self.set_state(salobj.State.STANDBY)
 
+    def set_rem_loglevel(self, level):
+        """Set remotes log level.
+
+        Usefull to prevent the internal salobj warnings when read queues are
+        filled up.
+
+        Parameters
+        ----------
+        level : `int`
+            Log level.
+        """
+        for component in self.components:
+            logging.getLogger(component).setLevel(level)
+
     @property
     def components(self):
         """ List of components names.

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -727,8 +727,8 @@ class RemoteGroup:
     def set_rem_loglevel(self, level):
         """Set remotes log level.
 
-        Usefull to prevent the internal salobj warnings when read queues are
-        filled up.
+        Useful to prevent the internal salobj warnings when read queues are
+        filling up.
 
         Parameters
         ----------


### PR DESCRIPTION
  * Add workaround to edge condition while homing the ATDome.
    If the dome is pressing the home switch and we send a home command, it will simply register the dome as homed and won't send any event to indicate the activity is complete.
  * Add method to reset all offsets in base_tcs.
  * Add set_rem_loglevel method in RemoteGroup, that allows users to set the log level for the remotes loggers.
  * Fix "restore check" feature in prepare for flats.
  * Fix direction of PhysicalSky rotator strategy.
  * Update ATCS to support specifying rotator park position and flat field position.
    When using point_azel to slew the telescope for a safe position, use the current nasmyth position.
  * Fix setting rotFrame in xml7/8 compatibility mode.
  * Update ronchi170lpmm sweet spot.
  * Support differential ra/dec tracking in BaseTCS.