### PR TITLE
CAP-856: update for ts_salobj 7

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,14 +2,14 @@
 This configuration only affects single-package Sphinx documentation builds.
 """
 
-from documenteer.conf.pipelinespkg import *
-import lsst.ts.observatory.control
+from documenteer.conf.pipelinespkg import *  # noqa
+import lsst.ts.observatory.control  # noqa
 
 project = "ts_observatory_control"
-html_theme_options["logotext"] = project
+html_theme_options["logotext"] = project  # type: ignore # noqa
 html_title = project
 html_short_title = project
 doxylink = {}  # Avoid warning: Could not find tag file _doxygen/doxygen.tag
 
-intersphinx_mapping["ts_xml"] = ("https://ts-xml.lsst.io", None)
-intersphinx_mapping["ts_salobj"] = ("https://ts-salobj.lsst.io", None)
+intersphinx_mapping["ts_xml"] = ("https://ts-xml.lsst.io", None)  # type: ignore # noqa
+intersphinx_mapping["ts_salobj"] = ("https://ts-salobj.lsst.io", None)  # type: ignore # noqa

--- a/doc/user-guide/auxtel/atcs-user-guide.rst
+++ b/doc/user-guide/auxtel/atcs-user-guide.rst
@@ -86,7 +86,7 @@ This method will perform the following tasks subsequently;
   #.  Once dome is open, open primary mirror cover and vent gates.
   #.  Enable ``ATAOS`` corrections.
 
-In general, it is advised to make sure all components are in ``ENABLED`` state before running :py:meth:`prepare_for_onsky <lsst.ts.observatory.control.auxtel.ATCS.prepare_for_onsky>`, but the method also accepts a dictionary of ``settings`` and calls :py:meth:`enable <lsst.ts.observatory.control.RemoteGroup.enable>` at the beginning.
+In general, it is advised to make sure all components are in ``ENABLED`` state before running :py:meth:`prepare_for_onsky <lsst.ts.observatory.control.auxtel.ATCS.prepare_for_onsky>`, but the method also accepts a dictionary of ``overrides`` and calls :py:meth:`enable <lsst.ts.observatory.control.RemoteGroup.enable>` at the beginning.
 
 .. code:: python
 
@@ -101,18 +101,18 @@ In general, it is advised to make sure all components are in ``ENABLED`` state b
 
 Following up on what was shown in :ref:`user-guide-generic-csc-group-behavior`, the following is also a valid way of running :py:meth:`prepare_for_onsky <lsst.ts.observatory.control.auxtel.ATCS.prepare_for_onsky>`.
 
-Overriding the settings for a single component (e.g. ATAOS):
+Overriding the overrides for a single component (e.g. ATAOS):
 
 .. code:: python
 
-    await atcs.prepare_for_onsky(settings={"ataos": "constant_hex"})
+    await atcs.prepare_for_onsky(overrides={"ataos": "constant_hex"})
 
-Or Overriding the settings for all components:
+Or Overriding the overrides for all components:
 
 .. code:: python
 
     await atcs.prepare_for_onsky(
-        settings={
+        overrides={
             "ataos": "current",
             "atmcs": "",
             "atptg": "",
@@ -124,7 +124,7 @@ Or Overriding the settings for all components:
     )
 
 It is important to remember that, if the components are already enabled, they will be left in the ``ENABLED`` state and will not be re-cycled.
-If you need to change the settings for a specific CSC, you will have to send it to ``STANDBY`` state first.
+If you need to change the overrides for a specific CSC, you will have to send it to ``STANDBY`` state first.
 See :ref:`user-guide-generic-csc-group-behavior` for an example of how to use :py:meth:`set_state <lsst.ts.observatory.control.RemoteGroup.set_state>` to send individual CSCs in the group to ``STANDBY`` state.
 
 All the slew methods discussed in :ref:`user-guide-generic-telescope-control-operations` are available in :py:class:`ATCS <lsst.ts.observatory.control.auxtel.ATCS>`, which can be used with :py:attr:`ATCSUsages.Slew <lsst.ts.observatory.control.auxtel.ATCSUsages.Slew>` to limit resource allocation, e.g.;

--- a/doc/user-guide/user-guide.rst
+++ b/doc/user-guide/user-guide.rst
@@ -140,7 +140,7 @@ Limiting Resources
 ------------------
 
 When writing a `SAL Script`_, it is very likely that only a small subset of topics (commands, events and telemetry) from a CSC group will be required.
-For instance, a `SAL Script`_ that will enable all components on a group, will only require the components ``summaryState`` and ``settingVersions`` events and the state transition commands.
+For instance, a `SAL Script`_ that will enable all components on a group, will only require the components ``summaryState`` and ``configurationsAvailable`` events and the state transition commands.
 In this case, it is possible to save some time and resources by limiting the group class to subscribe only to the required set, instead of the full topics set.
 
 The package allow users to do that through the ``intended_usage`` parameter.
@@ -188,15 +188,13 @@ Probably the most commonly used generic operations are the :py:meth:`enable <lss
 The idea is that, after running :py:meth:`enable <lsst.ts.observatory.control.RemoteGroup.enable>`, all CSCs in the group will be in the ``ENABLED`` state.
 Components that where already in ``ENABLED`` state will be left in that state.
 For components in any other state the method will make sure to send the required state transition commands to enable them.
-The method can run without any input argument, though one must be aware that it need to know what setting to load when transition from ``STANDBY`` to ``DISABLED``.
-If no input is given, the method will inspect the ``settingVersions`` event from the CSCs in the group and select the first item in ``settingVersions.recommendedSettingsLabels``.
-It is possible to provide settings either partially of fully using the ``settings`` input parameter.
+The method can run without any input argument.
 
 Following are a couple of examples of how to use the :py:meth:`enable <lsst.ts.observatory.control.RemoteGroup.enable>` method.
 
-.. TODO: (DM-26261) Add/Document feature to inspect all settings from all components in a group.
+.. TODO: (DM-26261) Add/Document feature to inspect all overrides from all components in a group.
 
-This will inspect the ``settingVersions`` event from all CSCs in the `ATCS` group to determine the ``settingsToApply`` for each one of them.
+This will inspect the ``configurationsAvailable`` event from all CSCs in the `ATCS` group to determine the ``override`` for each one of them.
 
 .. code:: python
 
@@ -208,20 +206,19 @@ This will inspect the ``settingVersions`` event from all CSCs in the `ATCS` grou
 
     await atcs.enable()
 
-Override settings for ATAOS only.
-Will inspect ``settingVersions`` event from all other CSCs in the group to determine the ``settingsToApply`` for the rest of them.
+Override the default configuration for ATAOS.
 
 .. code:: python
 
-    await atcs.enable(settings={"ataos": "constant_hex"})
+    await atcs.enable(overrides={"ataos": "constant_hex"})
 
-And finally, override settings for all the CSCs in the group.
-Note how some of them receive an empty string, which is a way of enabling the CSC with default settings (and also work for when the CSC is not configurable).
+And finally, override overrides for all the CSCs in the group.
+Note how some of them receive an empty string, which is a way of enabling the CSC with default overrides (and also work for when the CSC is not configurable).
 
 .. code:: python
 
     await atcs.enable(
-        settings={
+        overrides={
             "ataos": "current",
             "atmcs": "",
             "atptg": "",

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ###############
 
+v0.15.0
+-------
+
+* Update for ts_salobj v7, which is required.
+  This also requires ts_xml 11.
+
 v0.14.0
 -------
 

--- a/python/lsst/ts/observatory/control/auxtel/atcs.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcs.py
@@ -442,7 +442,7 @@ class ATCS(BaseTCS):
 
         return stop_results
 
-    async def prepare_for_onsky(self, settings=None):
+    async def prepare_for_onsky(self, overrides=None):
         """Prepare Auxiliary Telescope for on-sky operations.
 
         This method will perform the start of the night procedure for the
@@ -451,9 +451,9 @@ class ATCS(BaseTCS):
 
         Parameters
         ----------
-        settings: `dict`
-            Dictionary with settings to apply.  If `None` use the recommended
-            settings.
+        overrides: `dict`
+            Dictionary with overrides to apply.  If `None` use the recommended
+            overrides.
         """
 
         await self.assert_all_enabled(
@@ -1933,7 +1933,7 @@ class ATCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 atmcs=[
@@ -2007,7 +2007,7 @@ class ATCS(BaseTCS):
             usages[self.valid_use_cases.Slew] = UsagesResources(
                 components_attr=self.components_attr,
                 readonly=False,
-                generics=["summaryState", "settingVersions", "heartbeat"],
+                generics=["summaryState", "configurationsAvailable", "heartbeat"],
                 atmcs=[
                     "allAxesInPosition",
                     "atMountState",
@@ -2054,7 +2054,7 @@ class ATCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 atmcs=[
@@ -2115,7 +2115,7 @@ class ATCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 atmcs=[
@@ -2164,7 +2164,7 @@ class ATCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 atmcs=[

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -1713,14 +1713,14 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def prepare_for_onsky(self, settings=None):
+    async def prepare_for_onsky(self, overrides=None):
         """Prepare telescope for on-sky operations.
 
         Parameters
         ----------
-        settings: `dict`
-            Dictionary with settings to apply.  If `None` use the recommended
-            settings.
+        overrides: `dict`
+            Dictionary with overrides to apply.  If `None` use the recommended
+            overrides.
         """
         raise NotImplementedError
 

--- a/python/lsst/ts/observatory/control/maintel/comcam.py
+++ b/python/lsst/ts/observatory/control/maintel/comcam.py
@@ -296,7 +296,7 @@ class ComCam(BaseCamera):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 cccamera=[

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -623,7 +623,7 @@ class MTCS(BaseTCS):
         # TODO: Implement (DM-21336).
         raise NotImplementedError("# TODO: Implement (DM-21336).")
 
-    def prepare_for_onsky(self, settings=None):
+    def prepare_for_onsky(self, overrides=None):
         # TODO: Implement (DM-21336).
         raise NotImplementedError("# TODO: Implement (DM-21336).")
 
@@ -1226,7 +1226,7 @@ class MTCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 mtptg=[
@@ -1256,7 +1256,7 @@ class MTCS(BaseTCS):
             usages[self.valid_use_cases.Slew] = UsagesResources(
                 components_attr=self.components_attr,
                 readonly=False,
-                generics=["summaryState", "settingVersions", "heartbeat"],
+                generics=["summaryState", "configurationsAvailable", "heartbeat"],
                 mtptg=[
                     "azElTarget",
                     "raDecTarget",
@@ -1293,7 +1293,7 @@ class MTCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 mtptg=["azElTarget", "stopTracking", "focusNameSelected"],
@@ -1317,7 +1317,7 @@ class MTCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
                 mtptg=["azElTarget", "stopTracking", "focusNameSelected"],
@@ -1341,7 +1341,7 @@ class MTCS(BaseTCS):
                     "exitControl",
                     "enterControl",
                     "summaryState",
-                    "settingVersions",
+                    "configurationsAvailable",
                     "heartbeat",
                 ],
             )

--- a/python/lsst/ts/observatory/control/mock/atcs_mock.py
+++ b/python/lsst/ts/observatory/control/mock/atcs_mock.py
@@ -95,8 +95,6 @@ class ATCSMock(BaseGroupMock):
         self.dom_az = 0.0
         self.is_dome_homming = False
 
-        self.m1_cover_state = ATPneumatics.MirrorCoverState.CLOSED
-
         self.track = False
 
         self.atmcs_telemetry_task = None
@@ -159,9 +157,8 @@ class ATCSMock(BaseGroupMock):
             self.atpneumatics.evt_m1CoverState.data.state
         )
 
-    @m1_cover_state.setter
-    def m1_cover_state(self, value):
-        self.atpneumatics.evt_m1CoverState.set_put(state=value)
+    async def set_m1_cover_state(self, value):
+        await self.atpneumatics.evt_m1CoverState.set_write(state=value)
 
     async def start_task_publish(self):
 
@@ -170,10 +167,14 @@ class ATCSMock(BaseGroupMock):
 
         await super().start_task_publish()
 
-        self.atmcs.evt_atMountState.set_put(state=ATMCS.AtMountState.TRACKINGDISABLED)
-        self.atdome.evt_scbLink.set_put(active=True, force_output=True)
-        self.atdome.evt_azimuthCommandedState.put()
-        self.atptg.evt_focusNameSelected.set_put(focus=ATPtg.Foci.NASMYTH2)
+        await self.set_m1_cover_state(ATPneumatics.MirrorCoverState.CLOSED)
+
+        await self.atmcs.evt_atMountState.set_write(
+            state=ATMCS.AtMountState.TRACKINGDISABLED
+        )
+        await self.atdome.evt_scbLink.set_write(active=True, force_output=True)
+        await self.atdome.evt_azimuthCommandedState.write()
+        await self.atptg.evt_focusNameSelected.set_write(focus=ATPtg.Foci.NASMYTH2)
 
         self.atmcs_telemetry_task = asyncio.create_task(self.atmcs_telemetry())
         self.atdome_telemetry_task = asyncio.create_task(self.atdome_telemetry())
@@ -183,17 +184,17 @@ class ATCSMock(BaseGroupMock):
     async def atmcs_telemetry(self):
         while self.run_telemetry_loop:
 
-            self.atmcs.tel_mount_AzEl_Encoders.set_put(
+            await self.atmcs.tel_mount_AzEl_Encoders.set_write(
                 elevationCalculatedAngle=np.zeros(100) + self.tel_alt,
                 azimuthCalculatedAngle=np.zeros(100) + self.tel_az,
             )
 
-            self.atmcs.tel_mount_Nasmyth_Encoders.put()
+            await self.atmcs.tel_mount_Nasmyth_Encoders.write()
 
-            self.atpneumatics.evt_m1VentsPosition.put()  # only output when it changes
+            await self.atpneumatics.evt_m1VentsPosition.write()  # only output when it changes
 
             if self.track:
-                self.atmcs.evt_target.set_put(
+                await self.atmcs.evt_target.set_write(
                     elevation=self.tel_alt, azimuth=self.tel_az, force_output=True
                 )
 
@@ -201,8 +202,8 @@ class ATCSMock(BaseGroupMock):
 
     async def atdome_telemetry(self):
         while self.run_telemetry_loop:
-            self.atdome.tel_position.set_put(azimuthPosition=self.dom_az)
-            self.atdome.evt_azimuthState.set_put(homing=self.is_dome_homming)
+            await self.atdome.tel_position.set_write(azimuthPosition=self.dom_az)
+            await self.atdome.evt_azimuthState.set_write(homing=self.is_dome_homming)
             await asyncio.sleep(1.0)
 
     async def atptg_telemetry(self):
@@ -222,13 +223,13 @@ class ATCSMock(BaseGroupMock):
             else:
                 time_and_date.lst = now.sidereal_time("mean", self.location.lon).value
 
-            self.atptg.tel_timeAndDate.put(time_and_date)
+            await self.atptg.tel_timeAndDate.write(time_and_date)
 
             await asyncio.sleep(1.0)
 
     async def ataos_telemetry(self):
 
-        self.ataos.evt_correctionEnabled.set_put()
+        await self.ataos.evt_correctionEnabled.set_write()
 
         correction_times = cycle((1, 1, 2, 4, 10))
         while self.run_telemetry_loop:
@@ -238,34 +239,34 @@ class ATCSMock(BaseGroupMock):
                     if getattr(
                         self.ataos.evt_correctionEnabled.data, correction
                     ) and hasattr(self.ataos, f"evt_{correction}CorrectionStarted"):
-                        getattr(
+                        await getattr(
                             self.ataos, f"evt_{correction}CorrectionStarted"
-                        ).set_put(force_output=True)
+                        ).set_write(force_output=True)
                 await asyncio.sleep(0.5)
                 for correction in self.ataos_corrections:
                     if getattr(
                         self.ataos.evt_correctionEnabled.data, correction
                     ) and hasattr(self.ataos, f"evt_{correction}CorrectionCompleted"):
-                        getattr(
+                        await getattr(
                             self.ataos, f"evt_{correction}CorrectionCompleted"
-                        ).set_put(force_output=True)
+                        ).set_write(force_output=True)
             await asyncio.sleep(next(correction_times))
 
     async def atmcs_wait_and_fault(self, wait_time):
-        self.atmcs.evt_summaryState.set_put(
+        await self.atmcs.evt_summaryState.set_write(
             summaryState=salobj.State.ENABLED, force_output=True
         )
         await asyncio.sleep(wait_time)
-        self.atmcs.evt_summaryState.set_put(
+        await self.atmcs.evt_summaryState.set_write(
             summaryState=salobj.State.FAULT, force_output=True
         )
 
     async def atptg_wait_and_fault(self, wait_time):
-        self.atptg.evt_summaryState.set_put(
+        await self.atptg.evt_summaryState.set_write(
             summaryState=salobj.State.ENABLED, force_output=True
         )
         await asyncio.sleep(wait_time)
-        self.atptg.evt_summaryState.set_put(
+        await self.atptg.evt_summaryState.set_write(
             summaryState=salobj.State.FAULT, force_output=True
         )
 
@@ -320,15 +321,15 @@ class ATCSMock(BaseGroupMock):
 
     async def open_m1_cover(self):
         await asyncio.sleep(0.5)
-        self.m1_cover_state = ATPneumatics.MirrorCoverState.INMOTION
+        await self.set_m1_cover_state(ATPneumatics.MirrorCoverState.INMOTION)
         await asyncio.sleep(5.0)
-        self.m1_cover_state = ATPneumatics.MirrorCoverState.OPENED
+        await self.set_m1_cover_state(ATPneumatics.MirrorCoverState.OPENED)
 
     async def close_m1_cover(self):
         await asyncio.sleep(0.5)
-        self.m1_cover_state = ATPneumatics.MirrorCoverState.INMOTION
+        await self.set_m1_cover_state(ATPneumatics.MirrorCoverState.INMOTION)
         await asyncio.sleep(5.0)
-        self.m1_cover_state = ATPneumatics.MirrorCoverState.CLOSED
+        await self.set_m1_cover_state(ATPneumatics.MirrorCoverState.CLOSED)
 
     async def open_m1_cell_vents(self):
         self.atpneumatics.evt_m1VentsPosition.set(
@@ -352,14 +353,14 @@ class ATCSMock(BaseGroupMock):
         print("Homing dome")
         await asyncio.sleep(0.5)
         self.is_dome_homming = True
-        self.atdome.evt_azimuthCommandedState.set_put(
+        await self.atdome.evt_azimuthCommandedState.set_write(
             azimuth=0.0, commandedState=ATDome.AzimuthCommandedState.HOME
         )
 
         await asyncio.sleep(5.0)
         print("Dome homed")
         self.dom_az = 0.0
-        self.atdome.evt_azimuthCommandedState.set_put(
+        await self.atdome.evt_azimuthCommandedState.set_write(
             azimuth=0.0, commandedState=ATDome.AzimuthCommandedState.STOP
         )
         self.is_dome_homming = False
@@ -368,19 +369,25 @@ class ATCSMock(BaseGroupMock):
         """Fake slew waits 5 seconds, then reports all axes
         in position. Does not simulate the actual slew.
         """
-        self.atmcs.evt_allAxesInPosition.set_put(inPosition=False, force_output=True)
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=False, force_output=True)
+        await self.atmcs.evt_allAxesInPosition.set_write(
+            inPosition=False, force_output=True
+        )
+        await self.atdome.evt_azimuthInPosition.set_write(
+            inPosition=False, force_output=True
+        )
 
-        self.atdome.evt_azimuthCommandedState.put()
+        await self.atdome.evt_azimuthCommandedState.write()
         self.track = True
         self.task_list.append(asyncio.create_task(self.wait_and_send_inposition()))
 
     async def move_dome(self, data):
 
         print(f"Move dome {self.dom_az} -> {data.azimuth}")
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=False, force_output=True)
+        await self.atdome.evt_azimuthInPosition.set_write(
+            inPosition=False, force_output=True
+        )
 
-        self.atdome.evt_azimuthCommandedState.set_put(
+        await self.atdome.evt_azimuthCommandedState.set_write(
             azimuth=data.azimuth,
             commandedState=ATDome.AzimuthCommandedState.GOTOPOSITION,
             force_output=True,
@@ -389,32 +396,44 @@ class ATCSMock(BaseGroupMock):
         await asyncio.sleep(self.slew_time)
         self.dom_az = data.azimuth
 
-        self.atdome.evt_azimuthCommandedState.set_put(
+        await self.atdome.evt_azimuthCommandedState.set_write(
             azimuth=data.azimuth,
             commandedState=ATDome.AzimuthCommandedState.STOP,
             force_output=True,
         )
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=True, force_output=True)
+        await self.atdome.evt_azimuthInPosition.set_write(
+            inPosition=True, force_output=True
+        )
 
     async def stop_tracking_callback(self, data):
         print("Stop tracking start")
-        self.atmcs.evt_atMountState.set_put(state=ATMCS.AtMountState.STOPPING)
+        await self.atmcs.evt_atMountState.set_write(state=ATMCS.AtMountState.STOPPING)
         await asyncio.sleep(0.5)
         self.track = False
-        self.atmcs.evt_atMountState.set_put(state=ATMCS.AtMountState.TRACKINGDISABLED)
+        await self.atmcs.evt_atMountState.set_write(
+            state=ATMCS.AtMountState.TRACKINGDISABLED
+        )
         await asyncio.sleep(0.5)
-        self.atmcs.evt_allAxesInPosition.set_put(inPosition=False, force_output=True)
+        await self.atmcs.evt_allAxesInPosition.set_write(
+            inPosition=False, force_output=True
+        )
 
         print("Stop tracking end")
 
     async def wait_and_send_inposition(self):
 
         await asyncio.sleep(self.slew_time)
-        self.atmcs.evt_allAxesInPosition.set_put(inPosition=True, force_output=True)
+        await self.atmcs.evt_allAxesInPosition.set_write(
+            inPosition=True, force_output=True
+        )
         await asyncio.sleep(0.5)
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=True, force_output=True)
+        await self.atdome.evt_azimuthInPosition.set_write(
+            inPosition=True, force_output=True
+        )
 
-        self.atmcs.evt_atMountState.set_put(state=ATMCS.AtMountState.TRACKINGENABLED)
+        await self.atmcs.evt_atMountState.set_write(
+            state=ATMCS.AtMountState.TRACKINGENABLED
+        )
 
     async def move_shutter_callback(self, data):
         if data.open and self.dome_shutter_pos == 0.0:
@@ -442,15 +461,23 @@ class ATCSMock(BaseGroupMock):
                 f"should be {ATDome.ShutterDoorState.CLOSED!r}."
             )
 
-        self.atdome.evt_shutterInPosition.set_put(inPosition=False, force_output=True)
-        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.OPENING)
+        await self.atdome.evt_shutterInPosition.set_write(
+            inPosition=False, force_output=True
+        )
+        await self.atdome.evt_mainDoorState.set_write(
+            state=ATDome.ShutterDoorState.OPENING
+        )
         for self.dome_shutter_pos in np.linspace(0.0, 1.0, 10):
-            self.atdome.tel_position.set_put(
+            await self.atdome.tel_position.set_write(
                 mainDoorOpeningPercentage=self.dome_shutter_pos
             )
             await asyncio.sleep(self.slew_time / 10.0)
-        self.atdome.evt_shutterInPosition.set_put(inPosition=True, force_output=True)
-        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.OPENED)
+        await self.atdome.evt_shutterInPosition.set_write(
+            inPosition=True, force_output=True
+        )
+        await self.atdome.evt_mainDoorState.set_write(
+            state=ATDome.ShutterDoorState.OPENED
+        )
 
     async def close_shutter(self):
         if self.atdome.evt_mainDoorState.data.state != ATDome.ShutterDoorState.OPENED:
@@ -459,15 +486,23 @@ class ATCSMock(BaseGroupMock):
                 f"should be {ATDome.ShutterDoorState.OPENED!r}."
             )
 
-        self.atdome.evt_shutterInPosition.set_put(inPosition=False, force_output=True)
-        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.CLOSING)
+        await self.atdome.evt_shutterInPosition.set_write(
+            inPosition=False, force_output=True
+        )
+        await self.atdome.evt_mainDoorState.set_write(
+            state=ATDome.ShutterDoorState.CLOSING
+        )
         for self.dome_shutter_pos in np.linspace(1.0, 0.0, 10):
-            self.atdome.tel_position.set_put(
+            await self.atdome.tel_position.set_write(
                 mainDoorOpeningPercentage=self.dome_shutter_pos
             )
             await asyncio.sleep(self.slew_time / 10.0)
-        self.atdome.evt_shutterInPosition.set_put(inPosition=True, force_output=True)
-        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.CLOSED)
+        await self.atdome.evt_shutterInPosition.set_write(
+            inPosition=True, force_output=True
+        )
+        await self.atdome.evt_mainDoorState.set_write(
+            state=ATDome.ShutterDoorState.CLOSED
+        )
 
     async def atdome_start_callback(self, data):
         """ATDome start commands do more than the generic callback."""
@@ -482,16 +517,20 @@ class ATCSMock(BaseGroupMock):
 
         print(
             f"[atdome] {ss.data.summaryState!r} -> {salobj.State.DISABLED!r} "
-            f"[{data.settingsToApply}]"
+            f"[{data.configurationOverride}]"
         )
 
-        ss.set_put(summaryState=salobj.State.DISABLED)
+        await ss.set_write(summaryState=salobj.State.DISABLED)
 
-        self.settings_to_apply["atdome"] = data.settingsToApply
+        self.override["atdome"] = data.configurationOverride
 
-        self.atdome.evt_mainDoorState.set_put(state=ATDome.ShutterDoorState.CLOSED)
+        await self.atdome.evt_mainDoorState.set_write(
+            state=ATDome.ShutterDoorState.CLOSED
+        )
         self.atdome.tel_position.set(azimuthPosition=0.0)
-        self.atdome.evt_azimuthInPosition.set_put(inPosition=True, force_output=True)
+        await self.atdome.evt_azimuthInPosition.set_write(
+            inPosition=True, force_output=True
+        )
 
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -502,7 +541,7 @@ class ATCSMock(BaseGroupMock):
         for correction in self.ataos_corrections:
             if getattr(data, correction):
                 enable_corrections[correction] = True
-        self.ataos.evt_correctionEnabled.set_put(**enable_corrections)
+        await self.ataos.evt_correctionEnabled.set_write(**enable_corrections)
 
     async def ataos_disable_corrections(self, data):
         """"""
@@ -511,7 +550,7 @@ class ATCSMock(BaseGroupMock):
         for correction in self.ataos_corrections:
             if getattr(data, correction):
                 disable_corrections[correction] = False
-        self.ataos.evt_correctionEnabled.set_put(**disable_corrections)
+        await self.ataos.evt_correctionEnabled.set_write(**disable_corrections)
 
     async def close(self):
 

--- a/python/lsst/ts/observatory/control/mock/comcam_mock.py
+++ b/python/lsst/ts/observatory/control/mock/comcam_mock.py
@@ -99,13 +99,13 @@ class ComCamMock(BaseGroupMock):
             )
         )
 
-        self.cccamera.evt_endReadout.set_put(
+        await self.cccamera.evt_endReadout.set_write(
             imageName=image_name,
             additionalKeys=":".join([key.strip() for key in additional_keys]),
             additionalValues=":".join([value.strip() for value in additional_values]),
         )
         self.log.debug("sending LFOA")
-        self.ccheaderservice.evt_largeFileObjectAvailable.put()
+        await self.ccheaderservice.evt_largeFileObjectAvailable.write()
         self.log.debug("end_readout done")
 
     async def cmd_setFilter_callback(self, data):
@@ -115,7 +115,7 @@ class ComCamMock(BaseGroupMock):
     async def end_set_filter(self, data):
         """Wait for the filter to change and send endSetFilter event."""
         await asyncio.sleep(1)
-        self.cccamera.evt_endSetFilter.set_put(filterName=data.name)
+        await self.cccamera.evt_endSetFilter.set_write(filterName=data.name)
         self.log.debug("sending endSetFilter")
         self.camera_filter = data.name
 

--- a/python/lsst/ts/observatory/control/mock/latiss_mock.py
+++ b/python/lsst/ts/observatory/control/mock/latiss_mock.py
@@ -117,20 +117,20 @@ class LATISSMock(BaseGroupMock):
             )
         )
 
-        self.atcam.evt_endReadout.set_put(
+        await self.atcam.evt_endReadout.set_write(
             imageName=image_name,
             additionalKeys=":".join([key.strip() for key in additional_keys]),
             additionalValues=":".join([value.strip() for value in additional_values]),
         )
         self.log.debug("sending LFOA")
-        self.atheaderservice.evt_largeFileObjectAvailable.put()
+        await self.atheaderservice.evt_largeFileObjectAvailable.write()
         self.log.debug("end_readout done")
 
     async def cmd_changeFilter_callback(self, data):
         """Emulate change filter command"""
         await asyncio.sleep(0.1)
-        self.atspec.evt_filterInPosition.put()
-        self.atspec.evt_reportedFilterPosition.set_put(
+        await self.atspec.evt_filterInPosition.write()
+        await self.atspec.evt_reportedFilterPosition.set_write(
             slot=data.filter, name=f"filter{data.filter}", band="r"
         )
         self.latiss_filter = data.filter
@@ -138,9 +138,9 @@ class LATISSMock(BaseGroupMock):
     async def cmd_changeDisperser_callback(self, data):
         """Emulate change filter command"""
         await asyncio.sleep(0.1)
-        self.atspec.evt_disperserInPosition.put()
-        self.atspec.evt_reportedDisperserPosition.put()
-        self.atspec.evt_reportedDisperserPosition.set_put(
+        await self.atspec.evt_disperserInPosition.write()
+        await self.atspec.evt_reportedDisperserPosition.write()
+        await self.atspec.evt_reportedDisperserPosition.set_write(
             slot=data.disperser, name=f"grating{data.disperser}", band="R100"
         )
         self.latiss_grating = data.disperser
@@ -148,8 +148,8 @@ class LATISSMock(BaseGroupMock):
     async def cmd_moveLinearStage_callback(self, data):
         """Emulate change filter command"""
         await asyncio.sleep(0.1)
-        self.atspec.evt_linearStageInPosition.put()
-        self.atspec.evt_reportedLinearStagePosition.set_put(
+        await self.atspec.evt_linearStageInPosition.write()
+        await self.atspec.evt_reportedLinearStagePosition.set_write(
             position=data.distanceFromHome
         ),
         self.latiss_linear_stage = data.distanceFromHome

--- a/python/lsst/ts/observatory/control/mock/mtcs_mock.py
+++ b/python/lsst/ts/observatory/control/mock/mtcs_mock.py
@@ -142,10 +142,10 @@ class MTCSMock(BaseGroupMock):
 
         self.tracking = False
         self.acting = False
-        self.controllers.mtmount.evt_axesInPosition.set_put(
+        await self.controllers.mtmount.evt_axesInPosition.set_write(
             elevation=False, azimuth=False
         )
-        self.controllers.mtrotator.evt_inPosition.set_put(inPosition=False)
+        await self.controllers.mtrotator.evt_inPosition.set_write(inPosition=False)
 
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -212,17 +212,21 @@ class MTCSMock(BaseGroupMock):
 
     async def mount_telemetry(self):
 
-        self.controllers.mtmount.evt_elevationMotionState.set_put(
+        await self.controllers.mtmount.evt_elevationMotionState.set_write(
             state=MTMount.AxisMotionState.STOPPED
         )
-        self.controllers.mtmount.evt_azimuthMotionState.set_put(
+        await self.controllers.mtmount.evt_azimuthMotionState.set_write(
             state=MTMount.AxisMotionState.STOPPED
         )
-        self.controllers.mtmount.evt_cameraCableWrapMotionState.set_put(
+        await self.controllers.mtmount.evt_cameraCableWrapMotionState.set_write(
             state=MTMount.AxisMotionState.STOPPED
         )
-        self.controllers.mtmount.evt_cameraCableWrapFollowing.set_put(enabled=True)
-        self.controllers.mtmount.evt_connected.set_put(command=True, replies=True)
+        await self.controllers.mtmount.evt_cameraCableWrapFollowing.set_write(
+            enabled=True
+        )
+        await self.controllers.mtmount.evt_connected.set_write(
+            command=True, replies=True
+        )
 
         while self.run_telemetry_loop:
             if (
@@ -283,45 +287,45 @@ class MTCSMock(BaseGroupMock):
                 in_position_azimuth = np.abs(az_dif) < 1e-1 * u.deg
 
                 if self.acting:
-                    self.controllers.mtmount.evt_elevationMotionState.set_put(
+                    await self.controllers.mtmount.evt_elevationMotionState.set_write(
                         state=MTMount.AxisMotionState.TRACKING
                     )
-                    self.controllers.mtmount.evt_azimuthMotionState.set_put(
+                    await self.controllers.mtmount.evt_azimuthMotionState.set_write(
                         state=MTMount.AxisMotionState.TRACKING
                     )
-                    self.controllers.mtmount.evt_cameraCableWrapMotionState.set_put(
+                    await self.controllers.mtmount.evt_cameraCableWrapMotionState.set_write(
                         state=MTMount.AxisMotionState.TRACKING
                     )
-                    self.controllers.mtmount.evt_elevationInPosition.set_put(
+                    await self.controllers.mtmount.evt_elevationInPosition.set_write(
                         inPosition=in_position_elevation
                     )
-                    self.controllers.mtmount.evt_azimuthInPosition.set_put(
+                    await self.controllers.mtmount.evt_azimuthInPosition.set_write(
                         inPosition=in_position_azimuth
                     )
-                    self.controllers.mtmount.evt_cameraCableWrapInPosition.set_put(
+                    await self.controllers.mtmount.evt_cameraCableWrapInPosition.set_write(
                         inPosition=True
                     )
                 elif (
                     self.controllers.mtmount.evt_elevationMotionState.data.state
                     == MTMount.AxisState.TRACKING
                 ):
-                    self.controllers.mtmount.evt_elevationMotionState.set_put(
+                    await self.controllers.mtmount.evt_elevationMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPING
                     )
-                    self.controllers.mtmount.evt_azimuthMotionState.set_put(
+                    await self.controllers.mtmount.evt_azimuthMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPING
                     )
-                    self.controllers.mtmount.evt_cameraCableWrapMotionState.set_put(
+                    await self.controllers.mtmount.evt_cameraCableWrapMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPING
                     )
                 else:
-                    self.controllers.mtmount.evt_elevationMotionState.set_put(
+                    await self.controllers.mtmount.evt_elevationMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPED
                     )
-                    self.controllers.mtmount.evt_azimuthMotionState.set_put(
+                    await self.controllers.mtmount.evt_azimuthMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPED
                     )
-                    self.controllers.mtmount.evt_cameraCableWrapMotionState.set_put(
+                    await self.controllers.mtmount.evt_cameraCableWrapMotionState.set_write(
                         state=MTMount.AxisMotionState.STOPPED
                     )
                 # The following computation of angleActual is to emulate a
@@ -335,14 +339,14 @@ class MTCSMock(BaseGroupMock):
                 # achieved in one loop. By reducing STEP_FACTOR we can emulate
                 # a slew that takes a certain number of iterations to be
                 # completed.
-                self.controllers.mtmount.tel_azimuth.set_put(
+                await self.controllers.mtmount.tel_azimuth.set_write(
                     **{
                         self.mtmount_actual_position_name: az_actual
                         + az_induced_error
                         + az_dif.deg * STEP_FACTOR
                     }
                 )
-                self.controllers.mtmount.tel_elevation.set_put(
+                await self.controllers.mtmount.tel_elevation.set_write(
                     **{
                         self.mtmount_actual_position_name: el_actual
                         + el_induced_error
@@ -350,7 +354,7 @@ class MTCSMock(BaseGroupMock):
                     }
                 )
 
-                self.controllers.mtmount.tel_azimuthDrives.set_put(
+                await self.controllers.mtmount.tel_azimuthDrives.set_write(
                     current=np.random.normal(
                         loc=0.5,
                         scale=0.01,
@@ -361,7 +365,7 @@ class MTCSMock(BaseGroupMock):
                     timestamp=current_tai(),
                 )
 
-                self.controllers.mtmount.tel_elevationDrives.set_put(
+                await self.controllers.mtmount.tel_elevationDrives.set_write(
                     current=np.random.normal(
                         loc=0.5,
                         scale=0.01,
@@ -372,25 +376,25 @@ class MTCSMock(BaseGroupMock):
                     timestamp=current_tai(),
                 )
 
-                self.controllers.mtmount.tel_cameraCableWrap.set_put(
+                await self.controllers.mtmount.tel_cameraCableWrap.set_write(
                     actualPosition=self.controllers.mtrotator.tel_rotation.data.actualPosition,
                     timestamp=current_tai(),
                 )
-                self.controllers.mtmount.evt_cameraCableWrapTarget.set_put(
+                await self.controllers.mtmount.evt_cameraCableWrapTarget.set_write(
                     position=self.controllers.mtrotator.tel_rotation.data.actualPosition,
                     taiTime=current_tai(),
                     force_output=True,
                 )
 
-                self.controllers.mtmount.evt_target.put()
+                await self.controllers.mtmount.evt_target.write()
 
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 
     async def rotator_telemetry(self):
 
-        self.controllers.mtrotator.tel_electrical.set_put()
-        self.controllers.mtrotator.evt_connected.set_put(command=True, telemetry=True)
-        self.controllers.mtrotator.evt_configuration.set_put(
+        await self.controllers.mtrotator.tel_electrical.set_write()
+        await self.controllers.mtrotator.evt_connected.set_write(connected=True)
+        await self.controllers.mtrotator.evt_configuration.set_write(
             positionAngleUpperLimit=90.0,
             velocityLimit=3.0,
             accelerationLimit=1.0,
@@ -400,14 +404,14 @@ class MTCSMock(BaseGroupMock):
             trackingSuccessPositionThreshold=0.01,
             trackingLostTimeout=5.0,
         )
-        self.controllers.mtrotator.evt_controllerState.set_put(
+        await self.controllers.mtrotator.evt_controllerState.set_write(
             controllerState=0,
             offlineSubstate=1,
             enabledSubstate=0,
             applicationStatus=1024,
         )
 
-        self.controllers.mtrotator.evt_interlock.set_put(detail="Disengaged")
+        await self.controllers.mtrotator.evt_interlock.set_write(engaged=False)
 
         while self.run_telemetry_loop:
             if (
@@ -426,11 +430,11 @@ class MTCSMock(BaseGroupMock):
                 position = self.controllers.mtrotator.tel_rotation.data.actualPosition
                 dif = angle_diff(demand, position)
 
-                self.controllers.mtrotator.tel_rotation.set_put(
+                await self.controllers.mtrotator.tel_rotation.set_write(
                     actualPosition=position + error + dif.deg / 1.1
                 )
 
-                self.controllers.mtrotator.tel_motors.set_put(
+                await self.controllers.mtrotator.tel_motors.set_write(
                     calibrated=np.zeros(2)
                     + self.controllers.mtrotator.tel_rotation.data.actualPosition,
                     raw=27.4e6
@@ -440,22 +444,26 @@ class MTCSMock(BaseGroupMock):
                     ),
                 )
 
-                self.controllers.mtrotator.tel_ccwFollowingError.set_put(
+                await self.controllers.mtrotator.tel_ccwFollowingError.set_write(
                     timestamp=current_tai()
                 )
 
                 if self.acting:
-                    self.controllers.mtrotator.evt_target.set_put(
+                    await self.controllers.mtrotator.evt_target.set_write(
                         position=position,
                         velocity=0.0,
                         tai=current_tai(),
                     )
-                    self.controllers.mtrotator.evt_tracking.set_put(tracking=True)
-                    self.controllers.mtrotator.evt_inPosition.set_put(
+                    await self.controllers.mtrotator.evt_tracking.set_write(
+                        tracking=True
+                    )
+                    await self.controllers.mtrotator.evt_inPosition.set_write(
                         inPosition=np.abs(dif) < ROT_IN_POSITION_DELTA
                     )
                 else:
-                    self.controllers.mtrotator.evt_tracking.set_put(tracking=False)
+                    await self.controllers.mtrotator.evt_tracking.set_write(
+                        tracking=False
+                    )
 
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -506,9 +514,9 @@ class MTCSMock(BaseGroupMock):
                     positionActual=dome_el_pos + error_el + diff_el.deg / 1.1,
                 )
 
-                self.controllers.mtdome.tel_azimuth.put()
+                await self.controllers.mtdome.tel_azimuth.write()
 
-                self.controllers.mtdome.tel_lightWindScreen.put()
+                await self.controllers.mtdome.tel_lightWindScreen.write()
 
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 
@@ -538,7 +546,7 @@ class MTCSMock(BaseGroupMock):
                         "mean", self.location.lon
                     ).value
 
-                self.controllers.mtptg.tel_timeAndDate.put(time_and_date)
+                await self.controllers.mtptg.tel_timeAndDate.write(time_and_date)
 
                 if self.tracking:
                     radec_icrs = ICRS(
@@ -556,7 +564,7 @@ class MTCSMock(BaseGroupMock):
 
                     alt_az = radec_icrs.transform_to(coord_frame_altaz)
 
-                    self.controllers.mtptg.evt_currentTarget.set_put(
+                    await self.controllers.mtptg.evt_currentTarget.set_write(
                         timestamp=now.tai.mjd,
                         azDegs=alt_az.az.deg,
                         elDegs=alt_az.alt.deg,
@@ -614,7 +622,9 @@ class MTCSMock(BaseGroupMock):
 
                 accelerometer_data.accelerometer = accelerometer_data.rawAccelerometer
 
-                self.controllers.mtm1m3.tel_accelerometerData.put(accelerometer_data)
+                await self.controllers.mtm1m3.tel_accelerometerData.write(
+                    accelerometer_data
+                )
 
                 force_actuator_data = (
                     self.controllers.mtm1m3.tel_forceActuatorData.DataType()
@@ -650,7 +660,9 @@ class MTCSMock(BaseGroupMock):
                     + force_actuator_data.fz ** 2
                 )
 
-                self.controllers.mtm1m3.tel_forceActuatorData.put(force_actuator_data)
+                await self.controllers.mtm1m3.tel_forceActuatorData.write(
+                    force_actuator_data
+                )
 
                 hardpoint_actuator_data = (
                     self.controllers.mtm1m3.tel_hardpointActuatorData.DataType()
@@ -680,7 +692,7 @@ class MTCSMock(BaseGroupMock):
                 hardpoint_actuator_data.yRotation = np.random.normal()
                 hardpoint_actuator_data.zRotation = np.random.normal()
 
-                self.controllers.mtm1m3.tel_hardpointActuatorData.put(
+                await self.controllers.mtm1m3.tel_hardpointActuatorData.write(
                     hardpoint_actuator_data
                 )
 
@@ -720,7 +732,7 @@ class MTCSMock(BaseGroupMock):
                     size=len(hardpoint_monitor_data.pressureSensor3),
                 )
 
-                self.controllers.mtm1m3.tel_hardpointMonitorData.put(
+                await self.controllers.mtm1m3.tel_hardpointMonitorData.write(
                     hardpoint_monitor_data
                 )
 
@@ -747,7 +759,7 @@ class MTCSMock(BaseGroupMock):
                     dtype=int,
                 )
             # This will only publish if there is a change in the topic.
-            self.controllers.mtm1m3.evt_forceActuatorState.set_put(
+            await self.controllers.mtm1m3.evt_forceActuatorState.set_write(
                 **self.m1m3_force_actuator_state
             )
 
@@ -795,7 +807,7 @@ class MTCSMock(BaseGroupMock):
                 m1m3_topic_samples[topic_sample].pop(topic_attr)
 
             try:
-                getattr(self.controllers.mtm1m3, f"evt_{topic_sample}").set_put(
+                await getattr(self.controllers.mtm1m3, f"evt_{topic_sample}").set_write(
                     **m1m3_topic_samples[topic_sample]
                 )
             except Exception:

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -18,10 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 
-import types
 import asyncio
 import logging
+import re
 import traceback
+import types
 
 from lsst.ts import salobj
 from .utils import handle_exception_in_dict_items
@@ -81,7 +82,7 @@ class UsagesResources:
     `Usages.StateTransition`. It is relevant to all CSCs in the group,
     requires the generic state transition commands (`start`, `enable`,
     `disable`, `standby`) and the generic events `summaryState` and
-    `settingVersions`. To represent these resources for
+    `configurationsAvailable`. To represent these resources for
     `Usages.StateTransition` we create a `UsagesResources` with those
     requirements, e.g.::
 
@@ -94,7 +95,7 @@ class UsagesResources:
                         "disable",
                         "standby",
                         "summaryState",
-                        "settingVersions"
+                        "configurationsAvailable"
                        ]
             )
 
@@ -611,15 +612,15 @@ class RemoteGroup:
         assert len(exceptions) == 0, f"No heartbeat from {exceptions}."
 
     async def inspect_settings(self, components_attr=None):
-        """Return available settings.
+        """Return available overrides.
 
-        Inspect `settingVersions` from CSCs and return dictionary with all the
-        available settings.
+        Inspect `configurationsAvailable` from CSCs and return dictionary
+        with all the available overrides.
 
         Parameters
         ----------
         components_attr : `list` of `str` or `None`
-            List of CSC names from the group to inspect settings. If `None`
+            List of CSC names from the group to inspect overrides. If `None`
             inspect all components in the group. The name of the CSC must be as
             it appears in the `components_attr` attribute, which is the name of
             the CSC in lowercase, replacing ":" by "_" for indexed components,
@@ -627,8 +628,8 @@ class RemoteGroup:
 
         Returns
         -------
-        settings : `dict`
-            Dictionary with valid settings. The dictionary key will be the csc
+        overrides : `dict`
+            Dictionary with valid overrides. The dictionary key will be the csc
             name and the value a list of strings. The name of the CSC as it
             appears in the `components_attr` attribute, which is the name of
             the CSC in lowercase, replacing ":" by "_" for indexed components,
@@ -642,7 +643,7 @@ class RemoteGroup:
 
         """
 
-        settings = dict()
+        overrides = dict()
 
         for comp in (
             self.components_attr if components_attr is None else components_attr
@@ -652,14 +653,17 @@ class RemoteGroup:
                     f"{comp} not in group. Must be one of {self.components_attr}."
                 )
             elif getattr(self.check, comp):
-                settings[comp] = None
+                overrides[comp] = None
             else:
                 self.log.info(f"{comp} check is disabled, skipping.")
 
-        for comp in settings:
+        for comp in overrides:
             try:
-                if "settingVersions" in getattr(self.rem, comp).salinfo.event_names:
-                    sv = await getattr(self.rem, comp).evt_settingVersions.aget(
+                if (
+                    "configurationsAvailable"
+                    in getattr(self.rem, comp).salinfo.event_names
+                ):
+                    sv = await getattr(self.rem, comp).evt_configurationsAvailable.aget(
                         timeout=self.fast_timeout
                     )
                 else:
@@ -668,23 +672,23 @@ class RemoteGroup:
                 sv = None
 
             if sv is not None:
-                settings[comp] = sv.recommendedSettingsLabels.split(",")
+                overrides[comp] = re.split(", *", sv.overrides)
             else:
                 self.log.debug(
-                    "Couldn't get settingVersions event. Using empty settings."
+                    "Couldn't get configurationsAvailable event. Using empty settings."
                 )
-                settings[comp] = [""]
+                overrides[comp] = [""]
 
-        return settings
+        return overrides
 
-    async def expand_settings(self, settings=None):
-        """Take an incomplete settings dict and fills it out according to
+    async def expand_settings(self, overrides=None):
+        """Take an incomplete overrides dict and fills it out according to
         events published by components.
 
         Parameters
         ----------
-        settings : `dict` or `None`
-            A dictionary with (name, settings) pair or `None`. The name of the
+        overrides : `dict` or `None`
+            A dictionary with (name, overrides) pair or `None`. The name of the
             as it appears in the `components_attr` attribute, which is the name
             of the CSC in lowercase, replacing ":" by "_" for indexed
             components, e.g. "Hexapod:1" -> "hexapod_1" or "ATHexapod" ->
@@ -693,21 +697,21 @@ class RemoteGroup:
         Returns
         -------
         complete_settings : `dict`
-            Dictionary with complete settings.
+            Dictionary with complete overrides.
 
         Raises
         ------
         RuntimeError
-            If an item in the parameter `settings` dictionary is not a CSC in
+            If an item in the parameter `overrides` dictionary is not a CSC in
             the group.
 
         """
-        self.log.debug("Gathering settings.")
+        self.log.debug("Gathering overrides.")
 
         complete_settings = {}
-        if settings is not None:
-            self.log.debug(f"Received settings from users.: {settings}")
-            complete_settings = settings.copy()
+        if overrides is not None:
+            self.log.debug(f"Received overrides from users.: {overrides}")
+            complete_settings = overrides.copy()
             for comp in complete_settings:
                 if comp not in self.components_attr:
                     raise RuntimeError(
@@ -721,14 +725,14 @@ class RemoteGroup:
         )
 
         for comp in incomplete_settings:
-            self.log.debug(f"Complete settings for {comp}.")
+            self.log.debug(f"Complete overrides for {comp}.")
             complete_settings[comp] = incomplete_settings[comp][0]
 
         self.log.debug(f"Settings versions: {complete_settings}")
 
         return complete_settings
 
-    async def set_state(self, state, settings=None, components=None):
+    async def set_state(self, state, overrides=None, components=None):
         """Set summary state for all components.
 
         Parameters
@@ -736,7 +740,7 @@ class RemoteGroup:
         state : `salobj.State`
             Desired state.
 
-        settings : `dict`
+        overrides : `dict` or None
             Settings to apply for each component.
 
         components : `list[`str`]`
@@ -754,23 +758,18 @@ class RemoteGroup:
         """
         work_components = self.get_work_components(components)
 
-        if settings is not None:
-            settings_all = settings
-        else:
-            settings_all = dict([(comp, "") for comp in work_components])
+        if overrides is None:
+            overrides = dict()
 
         set_ss_tasks = []
 
         for comp in work_components:
             if getattr(self.check, comp):
-                settingsToApply = settings_all[comp]
-                if settingsToApply is None:
-                    settingsToApply = ""
                 set_ss_tasks.append(
                     salobj.set_summary_state(
-                        getattr(self.rem, comp),
-                        salobj.State(state),
-                        settingsToApply=settingsToApply,
+                        remote=getattr(self.rem, comp),
+                        state=salobj.State(state),
+                        override=overrides.get(comp, ""),
                         timeout=self.long_long_timeout,
                     )
                 )
@@ -896,26 +895,24 @@ class RemoteGroup:
 
         return software_versions
 
-    async def enable(self, settings=None):
+    async def enable(self, overrides=None):
         """Enable all components.
 
         This method will enable all group components. Users can provide
-        settings for the start command (in a dictionary). If no setting
-        is given for a component, it will use the first available setting
-        in `evt_settingVersions.recommendedSettingsLabels`.
+        overrides for the start command (in a dictionary).
 
         Parameters
         ----------
-        settings: `dict`
-            Dictionary with settings to apply.  If `None` use recommended
-            settings.
+        overrides: `dict`
+            Dictionary with overrides to apply.  If `None` use recommended
+            overrides.
         """
 
         self.log.info("Enabling all components")
 
-        settings_all = await self.expand_settings(settings)
+        overrides_all = await self.expand_settings(overrides)
 
-        await self.set_state(salobj.State.ENABLED, settings=settings_all)
+        await self.set_state(salobj.State.ENABLED, overrides=overrides_all)
 
     async def standby(self):
         """Put all CSCs in standby."""
@@ -1085,7 +1082,7 @@ class RemoteGroup:
                         "exitControl",
                         "enterControl",
                         "summaryState",
-                        "settingVersions",
+                        "configurationsAvailable",
                         "heartbeat",
                         "simulationMode",
                         "softwareVersions",
@@ -1102,7 +1099,7 @@ class RemoteGroup:
                         "exitControl",
                         "enterControl",
                         "summaryState",
-                        "settingVersions",
+                        "configurationsAvailable",
                     ],
                 ),
                 self.valid_use_cases.MonitorState: UsagesResources(

--- a/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
+++ b/python/lsst/ts/observatory/control/utils/remote_group_test_case.py
@@ -24,7 +24,6 @@ __all__ = ["RemoteGroupTestCase"]
 import abc
 import asyncio
 import contextlib
-import os
 import random
 import time
 
@@ -55,18 +54,15 @@ class RemoteGroupTestCase(metaclass=abc.ABCMeta):
 
     _index_iter = utils.index_generator()
 
-    def setUp(self) -> None:
-        salobj.set_random_lsst_dds_partition_prefix()
-        self.original_lsst_site = os.environ.get("LSST_SITE", None)
-        os.environ["LSST_SITE"] = "test"
+    def run(self, result=None):
+        """Override `run` to set a random LSST_DDS_PARTITION_PREFIX
+        and set LSST_SITE=test for every test.
 
-    def tearDown(self) -> None:
-        if not hasattr(self, "original_lsst_site"):
-            raise RuntimeError("Call super().setUp() in your setUp method")
-        if self.original_lsst_site is None:
-            del os.environ["LSST_SITE"]
-        else:
-            os.environ["LSST_SITE"] = self.original_lsst_site
+        https://stackoverflow.com/a/11180583
+        """
+        salobj.set_random_lsst_dds_partition_prefix()
+        with utils.modify_environ(LSST_SITE="test"):
+            super().run(result)
 
     @abc.abstractmethod
     async def basic_make_group(self, usage=None):

--- a/tests/auxtel/test_atcs.py
+++ b/tests/auxtel/test_atcs.py
@@ -17,10 +17,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
+
 import copy
 import types
 import asyncio
 import logging
+import os
 import unittest
 
 import numpy as np
@@ -1846,6 +1848,8 @@ class TestATTCS(unittest.IsolatedAsyncioTestCase):
         cls.track_id_gen = utils.index_generator(1)
 
     async def asyncSetUp(self):
+        self.original_lsst_site = os.environ.get("LSST_SITE", None)
+        os.environ["LSST_SITE"] = "test"
 
         # Setup asyncio facilities that probably failed while setting up class
         self.atcs._create_asyncio_events()
@@ -1975,7 +1979,7 @@ class TestATTCS(unittest.IsolatedAsyncioTestCase):
                         ),
                         "evt_heartbeat.next.side_effect": self.get_heartbeat,
                         "evt_heartbeat.aget.side_effect": self.get_heartbeat,
-                        "evt_settingVersions.aget.return_value": None,
+                        "evt_configurationsAvailable.aget.return_value": None,
                     }
                 ),
             )
@@ -2144,6 +2148,12 @@ class TestATTCS(unittest.IsolatedAsyncioTestCase):
             unittest.mock.Mock(),
             "flush",
         )
+
+    def tearDown(self) -> None:
+        if self.original_lsst_site is None:
+            del os.environ["LSST_SITE"]
+        else:
+            os.environ["LSST_SITE"] = self.original_lsst_site
 
     async def get_heartbeat(self, *args, **kwargs):
         """Emulate heartbeat functionality."""

--- a/tests/auxtel/test_atcs.py
+++ b/tests/auxtel/test_atcs.py
@@ -22,7 +22,6 @@ import copy
 import types
 import asyncio
 import logging
-import os
 import unittest
 
 import numpy as np
@@ -35,14 +34,360 @@ from astroquery.simbad import Simbad
 
 from lsst.ts import idl
 from lsst.ts.idl.enums import ATMCS, ATPtg, ATPneumatics, ATDome
-from lsst.ts import utils
 from lsst.ts import salobj
+from lsst.ts import utils
 
 from lsst.ts.observatory.control.auxtel.atcs import ATCS, ATCSUsages
 from lsst.ts.observatory.control.utils import RotType
 
 
 class TestATTCS(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        """This classmethod is only called once, when preparing the unit
+        test.
+        """
+
+        cls.log = logging.getLogger(__name__)
+
+        # Pass in a string as domain to prevent ATCS from trying to create a
+        # domain by itself. When using DryTest usage, the class won't create
+        # any remote. When this method is called there is no event loop
+        # running so all asyncio facilities will fail to create. This is later
+        # rectified in the asyncSetUp.
+        cls.atcs = ATCS(
+            domain="FakeDomain", log=cls.log, intended_usage=ATCSUsages.DryTest
+        )
+
+        # Decrease telescope settle time to speed up unit test
+        cls.atcs.tel_settle_time = 0.25
+
+        # Gather metadada information, needed to validate topics versions
+        cls.components_metadata = dict(
+            [
+                (
+                    component,
+                    salobj.parse_idl(
+                        component,
+                        idl.get_idl_dir()
+                        / f"sal_revCoded_{component.split(':')[0]}.idl",
+                    ),
+                )
+                for component in cls.atcs.components
+            ]
+        )
+
+        cls.track_id_gen = utils.index_generator(1)
+
+    def run(self, result=None):
+        """Override `run` to set a random LSST_DDS_PARTITION_PREFIX
+        and set LSST_SITE=test for every test.
+
+        https://stackoverflow.com/a/11180583
+        """
+        salobj.set_random_lsst_dds_partition_prefix()
+        with utils.modify_environ(LSST_SITE="test"):
+            super().run(result)
+
+    async def asyncSetUp(self):
+        # Setup asyncio facilities that probably failed while setting up class
+        self.atcs._create_asyncio_events()
+
+        # Setup required ATAOS data
+        self._ataos_evt_correction_enabled = types.SimpleNamespace(
+            m1=False,
+            hexapod=False,
+            m2=False,
+            focus=False,
+            atspectrograph=False,
+            moveWhileExposing=False,
+        )
+
+        # Setup required ATPtg data
+        self._atptg_evt_focus_name_selected = types.SimpleNamespace(
+            focus=ATPtg.Foci.NASMYTH2
+        )
+
+        # Setup required ATMCS data
+        self._telescope_position = types.SimpleNamespace(
+            elevationCalculatedAngle=np.zeros(100) + 80.0,
+            azimuthCalculatedAngle=np.zeros(100),
+        )
+
+        self._atmcs_tel_mount_nasmyth_encoders = types.SimpleNamespace(
+            nasmyth1CalculatedAngle=np.zeros(100), nasmyth2CalculatedAngle=np.zeros(100)
+        )
+
+        self._telescope_target_position = types.SimpleNamespace(
+            trackId=next(self.track_id_gen),
+            elevation=80.0,
+            azimuth=0.0,
+            nasmyth1RotatorAngle=0.0,
+            nasmyth2RotatorAngle=0.0,
+        )
+
+        self._atmcs_all_axes_in_position = types.SimpleNamespace(inPosition=True)
+
+        self._atmcs_evt_at_mount_state = types.SimpleNamespace(
+            state=int(ATMCS.AtMountState.TRACKINGDISABLED)
+        )
+
+        # Setup required ATDome data
+        self._atdome_position = types.SimpleNamespace(azimuthPosition=0.0)
+
+        self._atdome_azimth_commanded_state = types.SimpleNamespace(azimuth=0.0)
+
+        self._atdome_evt_azimuth_state = types.SimpleNamespace(
+            homing=False, _taken=False
+        )
+
+        self._atdome_evt_scb_link = types.SimpleNamespace(active=True)
+
+        self._atdome_evt_main_door_state = types.SimpleNamespace(
+            state=ATDome.ShutterDoorState.CLOSED
+        )
+
+        # Setup rquired ATDomeTrajectory data
+        self._atdometrajectory_dome_following = types.SimpleNamespace(enabled=False)
+
+        # Setup required ATPneumatics data
+        self._atpneumatics_evt_m1_cover_state = types.SimpleNamespace(
+            state=ATPneumatics.MirrorCoverState.CLOSED
+        )
+
+        self._atpneumatics_evt_m1_vents_position = types.SimpleNamespace(
+            position=ATPneumatics.VentsPosition.CLOSED
+        )
+
+        self._atpneumatics_evt_instrument_state = types.SimpleNamespace(
+            state=ATPneumatics.AirValveState.CLOSED
+        )
+
+        self._atpneumatics_evt_main_valve_state = types.SimpleNamespace(
+            state=ATPneumatics.AirValveState.CLOSED
+        )
+
+        # Setup data to support summary state manipulation
+        self.summary_state = dict(
+            [
+                (comp, types.SimpleNamespace(summaryState=int(salobj.State.ENABLED)))
+                for comp in self.atcs.components_attr
+            ]
+        )
+
+        self.summary_state_queue = dict(
+            [
+                (comp, [types.SimpleNamespace(summaryState=int(salobj.State.ENABLED))])
+                for comp in self.atcs.components_attr
+            ]
+        )
+
+        self.summary_state_queue_event = dict(
+            [(comp, asyncio.Event()) for comp in self.atcs.components_attr]
+        )
+
+        # Setup AsyncMock. The idea is to replace the placeholder for the
+        # remotes (in atcs.rem) by AsyncMock. The remote for each component is
+        # replaced by an AsyncMock and later augmented to emulate the behavior
+        # of the Remote->Controller interaction with side_effect and
+        # return_value.
+        # By default all mocks are augmented to handle summary state setting.
+        for component in self.atcs.components_attr:
+            setattr(
+                self.atcs.rem,
+                component,
+                unittest.mock.AsyncMock(
+                    **{
+                        "cmd_start.set_start.side_effect": self.set_summary_state_for(
+                            component, salobj.State.DISABLED
+                        ),
+                        "cmd_enable.start.side_effect": self.set_summary_state_for(
+                            component, salobj.State.ENABLED
+                        ),
+                        "cmd_disable.start.side_effect": self.set_summary_state_for(
+                            component, salobj.State.DISABLED
+                        ),
+                        "cmd_standby.start.side_effect": self.set_summary_state_for(
+                            component, salobj.State.STANDBY
+                        ),
+                        "evt_summaryState.next.side_effect": self.next_summary_state_for(
+                            component
+                        ),
+                        "evt_summaryState.aget.side_effect": self.get_summary_state_for(
+                            component
+                        ),
+                        "evt_heartbeat.next.side_effect": self.get_heartbeat,
+                        "evt_heartbeat.aget.side_effect": self.get_heartbeat,
+                        "evt_configurationsAvailable.aget.return_value": None,
+                    }
+                ),
+            )
+            # A trick to support calling a regular method (flush) from an
+            # AsyncMock. Basically, attach a regular Mock.
+            getattr(self.atcs.rem, f"{component}").evt_summaryState.attach_mock(
+                unittest.mock.Mock(),
+                "flush",
+            )
+
+        # Augment ataos mock.
+        self.atcs.rem.ataos.configure_mock(
+            **{
+                "evt_correctionEnabled.aget.side_effect": self.ataos_evt_correction_enabled
+            }
+        )
+        # Augment atptg mock.
+        self.atcs.rem.atptg.configure_mock(
+            **{
+                "evt_focusNameSelected.aget.side_effect": self.atptg_evt_focus_name_selected,
+                "cmd_stopTracking.start.side_effect": self.atmcs_stop_tracking,
+            }
+        )
+
+        self.atcs.rem.atptg.attach_mock(
+            unittest.mock.AsyncMock(),
+            "cmd_raDecTarget",
+        )
+
+        self.atcs.rem.atptg.cmd_raDecTarget.attach_mock(
+            unittest.mock.Mock(
+                **{
+                    "return_value": types.SimpleNamespace(
+                        **self.components_metadata["ATPtg"]
+                        .topic_info["command_raDecTarget"]
+                        .field_info
+                    )
+                }
+            ),
+            "DataType",
+        )
+
+        self.atcs.rem.atptg.cmd_poriginOffset.attach_mock(
+            unittest.mock.Mock(),
+            "set",
+        )
+
+        self.atcs.rem.atptg.cmd_raDecTarget.attach_mock(
+            unittest.mock.Mock(),
+            "set",
+        )
+
+        self.atcs.rem.atptg.cmd_azElTarget.attach_mock(
+            unittest.mock.Mock(),
+            "set",
+        )
+
+        # Augment atmcs mock
+        self.atcs.rem.atmcs.configure_mock(
+            **{
+                "tel_mount_Nasmyth_Encoders.aget.side_effect": self.atmcs_tel_mount_nasmyth_encoders,
+                "tel_mount_Nasmyth_Encoders.next.side_effect": self.atmcs_tel_mount_nasmyth_encoders,
+                "evt_allAxesInPosition.next.side_effect": self.atmcs_all_axes_in_position,
+                "evt_allAxesInPosition.aget.side_effect": self.atmcs_all_axes_in_position,
+                "evt_atMountState.aget.side_effect": self.atmcs_evt_at_mount_state,
+            }
+        )
+
+        self.atcs.rem.atmcs.evt_allAxesInPosition.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs.rem.atmcs.evt_atMountState.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs._tel_position = self._telescope_position
+        self.atcs._tel_target = self._telescope_target_position
+
+        self.atcs.next_telescope_position = unittest.mock.AsyncMock(
+            side_effect=self.next_telescope_position
+        )
+
+        self.atcs.next_telescope_target = unittest.mock.AsyncMock(
+            side_effect=self.next_telescope_target
+        )
+
+        # Augment atdome mock
+        self.atcs.rem.atdome.configure_mock(
+            **{
+                "tel_position.next.side_effect": self.atdome_tel_position,
+                "tel_position.aget.side_effect": self.atdome_tel_position,
+                "evt_azimuthCommandedState.aget.side_effect": self.atdome_evt_azimuth_commanded_state,
+                "evt_azimuthCommandedState.next.side_effect": self.atdome_evt_azimuth_commanded_state,
+                "evt_azimuthState.next.side_effect": self.atdome_evt_azimuth_state,
+                "evt_scbLink.aget.side_effect": self.atdome_evt_scb_link,
+                "evt_mainDoorState.aget.side_effect": self.atdome_evt_main_door_state,
+                "evt_mainDoorState.next.side_effect": self.atdome_evt_main_door_state,
+                "cmd_homeAzimuth.start.side_effect": self.atdome_cmd_home_azimuth,
+                "cmd_moveShutterMainDoor.set_start.side_effect": self.atdome_cmd_move_shutter_main_door,
+                "cmd_closeShutter.set_start.side_effect": self.atdome_cmd_close_shutter,
+            }
+        )
+
+        self.atcs.rem.atdome.evt_azimuthInPosition.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs.rem.atdome.evt_azimuthState.attach_mock(
+            unittest.mock.Mock(side_effect=self.atdome_evt_azimuth_state_flush),
+            "flush",
+        )
+
+        self.atcs.rem.atdome.evt_mainDoorState.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        # Augment atdometrajectory mock
+        self.atcs.rem.atdometrajectory.configure_mock(
+            **{
+                "evt_followingMode.aget.side_effect": self.atdometrajectory_following_mode,
+                "cmd_setFollowingMode.set_start.side_effect": self.atdometrajectory_cmd_set_following_mode,
+            }
+        )
+
+        # Augment atpneumatics mock
+        self.atcs.rem.atpneumatics.configure_mock(
+            **{
+                "evt_m1CoverState.aget.side_effect": self.atpneumatics_evt_m1_cover_state,
+                "evt_m1CoverState.next.side_effect": self.atpneumatics_evt_m1_cover_state,
+                "evt_m1VentsPosition.aget.side_effect": self.atpneumatics_evt_m1_vents_position,
+                "evt_m1VentsPosition.next.side_effect": self.atpneumatics_evt_m1_vents_position,
+                "evt_instrumentState.aget.side_effect": self.atpneumatics_evt_instrument_state,
+                "evt_instrumentState.next.side_effect": self.atpneumatics_evt_instrument_state,
+                "evt_mainValveState.aget.side_effect": self.atpneumatics_evt_main_valve_state,
+                "evt_mainValveState.next.side_effect": self.atpneumatics_evt_main_valve_state,
+                "cmd_openInstrumentAirValve.start.side_effect": self.atpneumatics_open_air_valve,
+                "cmd_openMasterAirSupply.start.side_effect": self.atpneumatics_open_main_valve,
+                "cmd_closeM1Cover.start.side_effect": self.atpneumatics_close_m1_cover,
+                "cmd_openM1Cover.start.side_effect": self.atpneumatics_open_m1_cover,
+                "cmd_openM1CellVents.start.side_effect": self.atpneumatics_open_m1_cell_vents,
+                "cmd_closeM1CellVents.start.side_effect": self.atpneumatics_close_m1_cell_vents,
+            }
+        )
+
+        self.atcs.rem.atpneumatics.evt_m1CoverState.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs.rem.atpneumatics.evt_m1VentsPosition.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs.rem.atpneumatics.evt_instrumentState.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
+        self.atcs.rem.atpneumatics.evt_mainValveState.attach_mock(
+            unittest.mock.Mock(),
+            "flush",
+        )
+
     def get_all_checks(self):
         check = copy.copy(self.atcs.check)
         for comp in self.atcs.components_attr:
@@ -1809,351 +2154,6 @@ class TestATTCS(unittest.IsolatedAsyncioTestCase):
                 attribute
                 in self.components_metadata[component].topic_info[topic].field_info
             )
-
-    @classmethod
-    def setUpClass(cls):
-        """This classmethod is only called once, when preparing the unit
-        test.
-        """
-
-        cls.log = logging.getLogger(__name__)
-
-        # Pass in a string as domain to prevent ATCS from trying to create a
-        # domain by itself. When using DryTest usage, the class won't create
-        # any remote. When this method is called there is no event loop
-        # running so all asyncio facilities will fail to create. This is later
-        # rectified in the asyncSetUp.
-        cls.atcs = ATCS(
-            domain="FakeDomain", log=cls.log, intended_usage=ATCSUsages.DryTest
-        )
-
-        # Decrease telescope settle time to speed up unit test
-        cls.atcs.tel_settle_time = 0.25
-
-        # Gather metadada information, needed to validate topics versions
-        cls.components_metadata = dict(
-            [
-                (
-                    component,
-                    salobj.parse_idl(
-                        component,
-                        idl.get_idl_dir()
-                        / f"sal_revCoded_{component.split(':')[0]}.idl",
-                    ),
-                )
-                for component in cls.atcs.components
-            ]
-        )
-
-        cls.track_id_gen = utils.index_generator(1)
-
-    async def asyncSetUp(self):
-        self.original_lsst_site = os.environ.get("LSST_SITE", None)
-        os.environ["LSST_SITE"] = "test"
-
-        # Setup asyncio facilities that probably failed while setting up class
-        self.atcs._create_asyncio_events()
-
-        # Setup required ATAOS data
-        self._ataos_evt_correction_enabled = types.SimpleNamespace(
-            m1=False,
-            hexapod=False,
-            m2=False,
-            focus=False,
-            atspectrograph=False,
-            moveWhileExposing=False,
-        )
-
-        # Setup required ATPtg data
-        self._atptg_evt_focus_name_selected = types.SimpleNamespace(
-            focus=ATPtg.Foci.NASMYTH2
-        )
-
-        # Setup required ATMCS data
-        self._telescope_position = types.SimpleNamespace(
-            elevationCalculatedAngle=np.zeros(100) + 80.0,
-            azimuthCalculatedAngle=np.zeros(100),
-        )
-
-        self._atmcs_tel_mount_nasmyth_encoders = types.SimpleNamespace(
-            nasmyth1CalculatedAngle=np.zeros(100), nasmyth2CalculatedAngle=np.zeros(100)
-        )
-
-        self._telescope_target_position = types.SimpleNamespace(
-            trackId=next(self.track_id_gen),
-            elevation=80.0,
-            azimuth=0.0,
-            nasmyth1RotatorAngle=0.0,
-            nasmyth2RotatorAngle=0.0,
-        )
-
-        self._atmcs_all_axes_in_position = types.SimpleNamespace(inPosition=True)
-
-        self._atmcs_evt_at_mount_state = types.SimpleNamespace(
-            state=int(ATMCS.AtMountState.TRACKINGDISABLED)
-        )
-
-        # Setup required ATDome data
-        self._atdome_position = types.SimpleNamespace(azimuthPosition=0.0)
-
-        self._atdome_azimth_commanded_state = types.SimpleNamespace(azimuth=0.0)
-
-        self._atdome_evt_azimuth_state = types.SimpleNamespace(
-            homing=False, _taken=False
-        )
-
-        self._atdome_evt_scb_link = types.SimpleNamespace(active=True)
-
-        self._atdome_evt_main_door_state = types.SimpleNamespace(
-            state=ATDome.ShutterDoorState.CLOSED
-        )
-
-        # Setup rquired ATDomeTrajectory data
-        self._atdometrajectory_dome_following = types.SimpleNamespace(enabled=False)
-
-        # Setup required ATPneumatics data
-        self._atpneumatics_evt_m1_cover_state = types.SimpleNamespace(
-            state=ATPneumatics.MirrorCoverState.CLOSED
-        )
-
-        self._atpneumatics_evt_m1_vents_position = types.SimpleNamespace(
-            position=ATPneumatics.VentsPosition.CLOSED
-        )
-
-        self._atpneumatics_evt_instrument_state = types.SimpleNamespace(
-            state=ATPneumatics.AirValveState.CLOSED
-        )
-
-        self._atpneumatics_evt_main_valve_state = types.SimpleNamespace(
-            state=ATPneumatics.AirValveState.CLOSED
-        )
-
-        # Setup data to support summary state manipulation
-        self.summary_state = dict(
-            [
-                (comp, types.SimpleNamespace(summaryState=int(salobj.State.ENABLED)))
-                for comp in self.atcs.components_attr
-            ]
-        )
-
-        self.summary_state_queue = dict(
-            [
-                (comp, [types.SimpleNamespace(summaryState=int(salobj.State.ENABLED))])
-                for comp in self.atcs.components_attr
-            ]
-        )
-
-        self.summary_state_queue_event = dict(
-            [(comp, asyncio.Event()) for comp in self.atcs.components_attr]
-        )
-
-        # Setup AsyncMock. The idea is to replace the placeholder for the
-        # remotes (in atcs.rem) by AsyncMock. The remote for each component is
-        # replaced by an AsyncMock and later augmented to emulate the behavior
-        # of the Remote->Controller interaction with side_effect and
-        # return_value.
-        # By default all mocks are augmented to handle summary state setting.
-        for component in self.atcs.components_attr:
-            setattr(
-                self.atcs.rem,
-                component,
-                unittest.mock.AsyncMock(
-                    **{
-                        "cmd_start.set_start.side_effect": self.set_summary_state_for(
-                            component, salobj.State.DISABLED
-                        ),
-                        "cmd_enable.start.side_effect": self.set_summary_state_for(
-                            component, salobj.State.ENABLED
-                        ),
-                        "cmd_disable.start.side_effect": self.set_summary_state_for(
-                            component, salobj.State.DISABLED
-                        ),
-                        "cmd_standby.start.side_effect": self.set_summary_state_for(
-                            component, salobj.State.STANDBY
-                        ),
-                        "evt_summaryState.next.side_effect": self.next_summary_state_for(
-                            component
-                        ),
-                        "evt_summaryState.aget.side_effect": self.get_summary_state_for(
-                            component
-                        ),
-                        "evt_heartbeat.next.side_effect": self.get_heartbeat,
-                        "evt_heartbeat.aget.side_effect": self.get_heartbeat,
-                        "evt_configurationsAvailable.aget.return_value": None,
-                    }
-                ),
-            )
-            # A trick to support calling a regular method (flush) from an
-            # AsyncMock. Basically, attach a regular Mock.
-            getattr(self.atcs.rem, f"{component}").evt_summaryState.attach_mock(
-                unittest.mock.Mock(),
-                "flush",
-            )
-
-        # Augment ataos mock.
-        self.atcs.rem.ataos.configure_mock(
-            **{
-                "evt_correctionEnabled.aget.side_effect": self.ataos_evt_correction_enabled
-            }
-        )
-        # Augment atptg mock.
-        self.atcs.rem.atptg.configure_mock(
-            **{
-                "evt_focusNameSelected.aget.side_effect": self.atptg_evt_focus_name_selected,
-                "cmd_stopTracking.start.side_effect": self.atmcs_stop_tracking,
-            }
-        )
-
-        self.atcs.rem.atptg.attach_mock(
-            unittest.mock.AsyncMock(),
-            "cmd_raDecTarget",
-        )
-
-        self.atcs.rem.atptg.cmd_raDecTarget.attach_mock(
-            unittest.mock.Mock(
-                **{
-                    "return_value": types.SimpleNamespace(
-                        **self.components_metadata["ATPtg"]
-                        .topic_info["command_raDecTarget"]
-                        .field_info
-                    )
-                }
-            ),
-            "DataType",
-        )
-
-        self.atcs.rem.atptg.cmd_poriginOffset.attach_mock(
-            unittest.mock.Mock(),
-            "set",
-        )
-
-        self.atcs.rem.atptg.cmd_raDecTarget.attach_mock(
-            unittest.mock.Mock(),
-            "set",
-        )
-
-        self.atcs.rem.atptg.cmd_azElTarget.attach_mock(
-            unittest.mock.Mock(),
-            "set",
-        )
-
-        # Augment atmcs mock
-        self.atcs.rem.atmcs.configure_mock(
-            **{
-                "tel_mount_Nasmyth_Encoders.aget.side_effect": self.atmcs_tel_mount_nasmyth_encoders,
-                "tel_mount_Nasmyth_Encoders.next.side_effect": self.atmcs_tel_mount_nasmyth_encoders,
-                "evt_allAxesInPosition.next.side_effect": self.atmcs_all_axes_in_position,
-                "evt_allAxesInPosition.aget.side_effect": self.atmcs_all_axes_in_position,
-                "evt_atMountState.aget.side_effect": self.atmcs_evt_at_mount_state,
-            }
-        )
-
-        self.atcs.rem.atmcs.evt_allAxesInPosition.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs.rem.atmcs.evt_atMountState.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs._tel_position = self._telescope_position
-        self.atcs._tel_target = self._telescope_target_position
-
-        self.atcs.next_telescope_position = unittest.mock.AsyncMock(
-            side_effect=self.next_telescope_position
-        )
-
-        self.atcs.next_telescope_target = unittest.mock.AsyncMock(
-            side_effect=self.next_telescope_target
-        )
-
-        # Augment atdome mock
-        self.atcs.rem.atdome.configure_mock(
-            **{
-                "tel_position.next.side_effect": self.atdome_tel_position,
-                "tel_position.aget.side_effect": self.atdome_tel_position,
-                "evt_azimuthCommandedState.aget.side_effect": self.atdome_evt_azimuth_commanded_state,
-                "evt_azimuthCommandedState.next.side_effect": self.atdome_evt_azimuth_commanded_state,
-                "evt_azimuthState.next.side_effect": self.atdome_evt_azimuth_state,
-                "evt_scbLink.aget.side_effect": self.atdome_evt_scb_link,
-                "evt_mainDoorState.aget.side_effect": self.atdome_evt_main_door_state,
-                "evt_mainDoorState.next.side_effect": self.atdome_evt_main_door_state,
-                "cmd_homeAzimuth.start.side_effect": self.atdome_cmd_home_azimuth,
-                "cmd_moveShutterMainDoor.set_start.side_effect": self.atdome_cmd_move_shutter_main_door,
-                "cmd_closeShutter.set_start.side_effect": self.atdome_cmd_close_shutter,
-            }
-        )
-
-        self.atcs.rem.atdome.evt_azimuthInPosition.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs.rem.atdome.evt_azimuthState.attach_mock(
-            unittest.mock.Mock(side_effect=self.atdome_evt_azimuth_state_flush),
-            "flush",
-        )
-
-        self.atcs.rem.atdome.evt_mainDoorState.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        # Augment atdometrajectory mock
-        self.atcs.rem.atdometrajectory.configure_mock(
-            **{
-                "evt_followingMode.aget.side_effect": self.atdometrajectory_following_mode,
-                "cmd_setFollowingMode.set_start.side_effect": self.atdometrajectory_cmd_set_following_mode,
-            }
-        )
-
-        # Augment atpneumatics mock
-        self.atcs.rem.atpneumatics.configure_mock(
-            **{
-                "evt_m1CoverState.aget.side_effect": self.atpneumatics_evt_m1_cover_state,
-                "evt_m1CoverState.next.side_effect": self.atpneumatics_evt_m1_cover_state,
-                "evt_m1VentsPosition.aget.side_effect": self.atpneumatics_evt_m1_vents_position,
-                "evt_m1VentsPosition.next.side_effect": self.atpneumatics_evt_m1_vents_position,
-                "evt_instrumentState.aget.side_effect": self.atpneumatics_evt_instrument_state,
-                "evt_instrumentState.next.side_effect": self.atpneumatics_evt_instrument_state,
-                "evt_mainValveState.aget.side_effect": self.atpneumatics_evt_main_valve_state,
-                "evt_mainValveState.next.side_effect": self.atpneumatics_evt_main_valve_state,
-                "cmd_openInstrumentAirValve.start.side_effect": self.atpneumatics_open_air_valve,
-                "cmd_openMasterAirSupply.start.side_effect": self.atpneumatics_open_main_valve,
-                "cmd_closeM1Cover.start.side_effect": self.atpneumatics_close_m1_cover,
-                "cmd_openM1Cover.start.side_effect": self.atpneumatics_open_m1_cover,
-                "cmd_openM1CellVents.start.side_effect": self.atpneumatics_open_m1_cell_vents,
-                "cmd_closeM1CellVents.start.side_effect": self.atpneumatics_close_m1_cell_vents,
-            }
-        )
-
-        self.atcs.rem.atpneumatics.evt_m1CoverState.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs.rem.atpneumatics.evt_m1VentsPosition.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs.rem.atpneumatics.evt_instrumentState.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-        self.atcs.rem.atpneumatics.evt_mainValveState.attach_mock(
-            unittest.mock.Mock(),
-            "flush",
-        )
-
-    def tearDown(self) -> None:
-        if self.original_lsst_site is None:
-            del os.environ["LSST_SITE"]
-        else:
-            os.environ["LSST_SITE"] = self.original_lsst_site
 
     async def get_heartbeat(self, *args, **kwargs):
         """Emulate heartbeat functionality."""

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -17,10 +17,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
+
+import asyncio
 import copy
 import logging
+import os
 import types
-import asyncio
 import unittest
 
 import astropy.units as units
@@ -1364,6 +1366,8 @@ class TestMTCS(unittest.IsolatedAsyncioTestCase):
         cls.track_id_gen = utils.index_generator(1)
 
     async def asyncSetUp(self):
+        self.original_lsst_site = os.environ.get("LSST_SITE", None)
+        os.environ["LSST_SITE"] = "test"
 
         self.mtcs._create_asyncio_events()
 
@@ -1494,7 +1498,7 @@ class TestMTCS(unittest.IsolatedAsyncioTestCase):
                         ),
                         "evt_heartbeat.next.side_effect": self.get_heartbeat,
                         "evt_heartbeat.aget.side_effect": self.get_heartbeat,
-                        "evt_settingVersions.aget.return_value": None,
+                        "evt_configurationsAvailable.aget.return_value": None,
                     }
                 ),
             )
@@ -1713,6 +1717,12 @@ class TestMTCS(unittest.IsolatedAsyncioTestCase):
         self.heartbeat_time = 1.0  # seconds
         self.short_process_time = 0.1  # seconds
         self.normal_process_time = 0.25  # seconds
+
+    def tearDown(self):
+        if self.original_lsst_site is None:
+            del os.environ["LSST_SITE"]
+        else:
+            os.environ["LSST_SITE"] = self.original_lsst_site
 
     async def get_heartbeat(self, *args, **kwargs):
         """Emulate heartbeat functionality."""

--- a/tests/test_base_group.py
+++ b/tests/test_base_group.py
@@ -99,28 +99,28 @@ class TestBaseGroup(RemoteGroupTestCase, unittest.IsolatedAsyncioTestCase):
             usage=Usages.StateTransition + Usages.MonitorHeartBeat
         ):
 
-            settings = await self.basegroup.inspect_settings()
+            overrides = await self.basegroup.inspect_settings()
 
             for comp in self.basegroup.components_attr:
-                with self.subTest(msg=f"Check settings for {comp}", component=comp):
-                    assert comp in settings
-                    assert len(settings[comp]) > 0
+                with self.subTest(msg=f"Check overrides for {comp}", component=comp):
+                    assert comp in overrides
+                    assert len(overrides[comp]) > 0
 
             for comp in self.basegroup.components_attr:
                 not_this = self.basegroup.components_attr.copy()
                 not_this.remove(comp)
-                settings = await self.basegroup.inspect_settings([comp])
+                overrides = await self.basegroup.inspect_settings([comp])
                 with self.subTest(
-                    msg=f"Check individual settings for {comp}", component=comp
+                    msg=f"Check individual overrides for {comp}", component=comp
                 ):
-                    assert comp in settings
-                    assert len(settings[comp]) > 0
+                    assert comp in overrides
+                    assert len(overrides[comp]) > 0
 
                 for not_comp in not_this:
                     with self.subTest(
-                        msg="{not_comp} not in settings.", component=comp
+                        msg="{not_comp} not in overrides.", component=comp
                     ):
-                        assert not_comp not in settings
+                        assert not_comp not in overrides
 
             with pytest.raises(RuntimeError):
                 await self.basegroup.inspect_settings(["nocomp"])


### PR DESCRIPTION
There are two changes I am a bit worried about:
* I changed "settings" to "overrides" to match our new usage. But this changes the API, which may break some notebooks. (It is easy to fix standardscripts and externalscripts).
* There are two places that write mock ATPtg timeAndDate data with values that did not match the XML units. I updated them to write `timestamp` in TAI seconds, instead of MJD days, and `utc` as MJD days instead of hours in the day. I hope that's really what the pointing components are doing. Many of the time fields in that topic look like duplicates of each other and the descriptions could use some work.

Also: the documentation claimed that the first settingsToApply value was always used as the settingsToApply if the user didn't specify anything else. Obviously the new best default is `configurationOverride=""` (rather than any of the available overrides). Unfortunately I could not find the code that extracted the first settingsToApply value. If you can find it, please point it out so we can fix that code.