### PR TITLE
Tickets/dm 37942 - Add methods to show and assert authorization status in {{RemoteGroup}}

### DIFF
--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -1210,7 +1210,23 @@ class RemoteGroup:
 
     async def show_auth_status(self) -> None:
         """Shows the authorization status of a group"""
-        raise NotImplementedError
+
+        async def _log_auth_status(c: salobj.Remote) -> None:
+            """Helper function to log authorization status"""
+            authList = await c.evt_authList.aget()
+            self.log.info(
+                f"private_identity: {authList.private_identity}, "
+                f"authorizedUsers: {authList.authorizedUsers}, "
+                f"nonAuthorizedCSCs: {authList.nonAuthorizedCSCs}"
+            )
+
+        await asyncio.gather(
+            *[
+                _log_auth_status(getattr(self.rem, c))
+                for c in self.components_attr
+                if getattr(self.rem, c) is not None
+            ]
+        )
 
     async def assert_user_is_authorized(
         self, user: typing.Optional[str] = None

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -1238,4 +1238,16 @@ class RemoteGroup:
         user : str or None, Default: None
             The user that should have the authorization to command all the CSCs in the group.
         """
-        raise NotImplementedError
+        identity = user if user else self.get_identity()
+        
+        async def _assert_user_is_authorized(c: salobj.Remote) -> None:
+            authList = await c.evt_authList.aget()
+            assert identity in authList.authorizedUsers
+        
+        await asyncio.gather(
+            *[
+                _log_auth_status(getattr(self.rem, c))
+                for c in self.components_attr
+                if getattr(self.rem, c) is not None
+            ]
+        )

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -1207,3 +1207,19 @@ class RemoteGroup:
 
     async def __aexit__(self, *args: typing.Any) -> None:
         await self.close()
+
+    async def show_auth_status(self) -> None:
+        """Shows the authorization status of a group"""
+        raise NotImplementedError
+
+    async def assert_user_is_authorized(
+        self, user: typing.Optional[str] = None
+    ) -> None:
+        """Asserts that the (current) user is authorized to command all the CSCs in the current group.
+
+        Parameters
+        ----------
+        user : str or None, Default: None
+            The user that should have the authorization to command all the CSCs in the group.
+        """
+        raise NotImplementedError

--- a/tests/test_base_group.py
+++ b/tests/test_base_group.py
@@ -236,3 +236,13 @@ class TestBaseGroup(RemoteGroupTestCase, unittest.IsolatedAsyncioTestCase):
     async def test_show_auth_status(self) -> None:
         async with self.make_group(usage=Usages.DryTest):
             await self.basegroup.show_auth_status()
+
+    async def test_assert_user_is_authorized(self) -> None:
+        async with self.make_group(
+            usage=Usages.DryTest
+        ), MockAuthorizeCsc() as authorize_csc:
+            await self.basegroup.request_authorization()
+            await self.basegroup.assert_user_is_authorized()
+            
+            identity = self.basegroup.get_identity()
+            await self.basegroup.assert_user_is_authorized(identity)

--- a/tests/test_base_group.py
+++ b/tests/test_base_group.py
@@ -232,3 +232,7 @@ class TestBaseGroup(RemoteGroupTestCase, unittest.IsolatedAsyncioTestCase):
 
             assert authorize_csc.authorized_users == f"-{self.basegroup.get_identity()}"
             assert authorize_csc.cscs_to_change == ",".join(self.basegroup.components)
+
+    async def test_show_auth_status(self) -> None:
+        async with self.make_group(usage=Usages.DryTest):
+            await self.basegroup.show_auth_status()


### PR DESCRIPTION
Add new utility methods in RemoteGroup to show the authorization status of a group and to assert that the user is authorized to command all CSCs in the group.

