### PR TITLE
DM-37978

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,33 @@
 Version History
 ###############
 
+v0.24.3
+-------
+
+
+* In ``tests/auxtel/test_atcs.py``,  implement some small improvements in the ``ATCS`` test case.
+
+  * Call ``atcs.enable_dome_following`` in all ``test_slew``.
+    This will make sure the ``monitor_loop`` runs and checks the dome position.
+
+  * Add two new slew tests:
+
+    * Test slew icrs when telescope timeout arriving in position.
+
+    * Test slew icrs when dome timeout arriving in position.
+
+* In ``mock/atcs_async_mock.py``, add mocking for the atdome move azimuth command and in position event.
+
+* In ``base_tcs.py``, update ``BaseTCS._handle_in_position`` debug message to also display the timeout.
+
+* In ``auxtel/atcs.py``, update ``ATCS.monitor_position`` to make log messages more similar to the ones in ``MTCS``.
+
+* In ``auxtel/atcs.py``, update  ``ATCS.wait_for_inposition`` to improve reporting of timeout failures.
+  Instead of appending coroutines to the `tasks` list, use ``asyncio.create_task`` and give names to each of the tasks.
+  Then, instead of simply gathering the tasks, which leads to uncomprehensive  tracebacks when tasks timeouts, capture any exception and reprocess the error messages re-raising them as `RuntimeError` with a more comprehensive message.
+
+* In ``auxtel/atcs``, update ``ATCS._slew`` to use the more robust ``asyncio.create_task`` instead of ``ensure_future`` when scheduling background tasks.
+
 v0.24.2
 -------
 

--- a/python/lsst/ts/observatory/control/base_tcs.py
+++ b/python/lsst/ts/observatory/control/base_tcs.py
@@ -1789,7 +1789,9 @@ class BaseTCS(RemoteGroup, metaclass=abc.ABCMeta):
         str
             Message indicating the component is in position.
         """
-        self.log.debug(f"Wait for {component_name} in position event.")
+        self.log.debug(
+            f"Wait for {component_name} in position event, (timeout={timeout}s)."
+        )
 
         in_position_event.flush()
         in_position = await in_position_event.aget(timeout=self.fast_timeout)

--- a/python/lsst/ts/observatory/control/mock/remote_group_async_mock.py
+++ b/python/lsst/ts/observatory/control/mock/remote_group_async_mock.py
@@ -117,6 +117,8 @@ class RemoteGroupAsyncMock(
         await self.setup_basic_mocks()
         await self.setup_mocks()
 
+        self.remote_group.reset_checks()
+
         return await super().asyncSetUp()
 
     @abc.abstractmethod

--- a/python/lsst/ts/observatory/control/remote_group.py
+++ b/python/lsst/ts/observatory/control/remote_group.py
@@ -978,6 +978,11 @@ class RemoteGroup:
 
         return work_components
 
+    def reset_checks(self) -> None:
+        """Reset all checks, enabling check for all components."""
+        for comp in self.components_attr:
+            setattr(self.check, comp, True)
+
     async def _aget_topic_samples_for_components(
         self,
         topic_name: str,


### PR DESCRIPTION
In the end, I figured that there was nothing wrong with the `monitor_position` loop. Most likely the original report was due to usage of the wrong version of the library. I also tried to track down the problem with the source finding algorithm but it seems do be working fine. 

In the end, the only thing I did was to improve the error messages for when the telescope and/or dome timeout arriving in position. I included tests for these two conditions and also made some small tweaks in the test to cover the condition monitor_position loop. 