### PR TITLE
A new CWFS star catalog described on Technote-058

### DIFF
--- a/python/lsst/ts/observatory/control/catalogs/HD_cwfs_stars.pd
+++ b/python/lsst/ts/observatory/control/catalogs/HD_cwfs_stars.pd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41cefaca2b1f7f2f3748c79ecce1e7c472728139a6878b25ab7ce15781144eb1
+size 7109273


### PR DESCRIPTION
This is a new CWFS star catalog generated from a notebook described on Technote-058. 
See also https://sitcomtn-058.lsst.io/v/SITCOM-616/index.html (work in progress), https://jira.lsstcorp.org/browse/SITCOM-616. 