### PR TITLE
SITCOM-781 - Create new move_m1m3_hp method in MTCS

### DIFF
--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -1120,27 +1120,24 @@ class MTCS(BaseTCS):
                     f"command - 1: {hpWarning.limitSwitch1Operated[hp_index]}"
                     f" 2: {hpWarning.limitSwitch2Operated[hp_index]}"
                 )
+                self.log.info(f"Stopping movement on Hardpoing {hp_index}")
+                await self.rem.mtm1m3.cmd_stopHardpointMotion.set_start(
+                    timeout=self.fast_timeout
+                )
                 break
 
             # Check if timed out
             if timer_task.done():
+                self.log.info(f"Stopping movement on Hardpoing {hp_index}")
+                await self.rem.mtm1m3.cmd_stopHardpointMotion.set_start(
+                    timeout=self.fast_timeout
+                )
                 raise TimeoutError(
                     f"Hardpoing {hp_index} did not move {step_size} steps within"
-                    f" {self.long_long_timeout} seconds."
+                    f" {self.long_long_timeout} seconds. Enforcing an stop command."
                 )
 
             hpActuatorState = await self.rem.mtm1m3.evt_hardpointActuatorState.next()
-
-        # TODO: Do we need the stopHardpointMotion command below? The code
-        #  sends a cmd_moveHardpointActuators and later sends a
-        #  cmd_stopHardpointMotion command. Why do we need the stop? I thought
-        #  that the hardpoint would stop moving when reaching its position or
-        #  when hitting a limit switch (see the while loop right above)
-
-        # Stop hardpoint motion
-        await self.rem.mtm1m3.cmd_stopHardpointMotion.set_start(
-            timeout=self.fast_timeout
-        )
 
         # Give a little buffer room before completing this part of the test
         await asyncio.sleep(1)

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -1243,3 +1243,14 @@ class TestMTCS(MTCSAsyncMock):
         self.mtcs.rem.mthexapod_2.evt_inPosition.next.assert_awaited_with(
             timeout=self.mtcs.long_timeout, flush=False
         )
+
+    async def test_move_m1m3_hp(self) -> None:
+        hp_index = 1
+        step_size = 1000
+
+        steps = [0] * 6
+        steps[hp_index] = step_size
+
+        await self.mtcs.move_m1m3_hp(hp_index=hp_index, step_size=step_size)
+
+        self._mthexapod_1_evt_compensation_mode.enabled = False


### PR DESCRIPTION
We want to extract and (if needed) refactor the code in [hardpoint_move](https://github.com/lsst-ts/ts_m1m3supporttesting/blob/develop/MTM1M3Movements.py#L533) and write it the extracted code into the new `MTCS.move_m1m3_hp` method.