### PR TITLE
DM-39213: AuxTel Observing Support.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,15 @@
 Version History
 ###############
 
+v0.27.1
+-------
+
+* In ``maintel/mtcs.py``:
+
+  * Add a specific timeout for the hard point test that is long enough to allow it to execute.
+  * Update ``run_m1m3_hard_point_test`` to wait for ``_wait_hard_point_test_ok``, catch timeout exceptions and raise a runtime error instead.
+  * Update ``enter_m1m3_engineering_mode`` to ignore timeout error in ``cmd_enterEngineering``.
+
 v0.27.0
 -------
 

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -123,6 +123,7 @@ class MTCS(BaseTCS):
         )
 
         self.open_dome_shutter_time = 1200.0
+        self.timeout_hardpoint_test_status = 600.0
 
         self.tel_park_el = 80.0
         self.tel_park_az = 0.0
@@ -879,7 +880,7 @@ class MTCS(BaseTCS):
             hp_test_state = MTM1M3.HardpointTest(
                 (
                     await self.rem.mtm1m3.evt_hardpointTestStatus.next(
-                        flush=False, timeout=self.long_timeout
+                        flush=False, timeout=self.timeout_hardpoint_test_status
                     )
                 ).testState[hp - 1]
             )

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -1032,7 +1032,21 @@ class MTCS(BaseTCS):
 
         if not await self.is_m1m3_in_engineering_mode():
             self.log.info("Entering m1m3 engineering mode.")
-            await self.rem.mtm1m3.cmd_enterEngineering.start(timeout=self.long_timeout)
+            try:
+                await self.rem.mtm1m3.cmd_enterEngineering.start(
+                    timeout=self.long_timeout
+                )
+            except asyncio.TimeoutError:
+                # TODO (DM-39458): Remove this workaround.
+                # This command was timing out frequently even though it is
+                # completing successfully. I will implement this workaround
+                # here while we investigate the problem. Note that it will
+                # still check that the m1m3 transitioned to the expected state
+                # afterwards.
+                self.log.warning(
+                    "Timeout waiting for ack for enter engineering command. Continuing..."
+                )
+
             await self._wait_for_mtm1m3_detailed_state(
                 expected_m1m3_detailed_state=self.m1m3_engineering_states,
                 unexpected_m1m3_detailed_states=set(),

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -1077,10 +1077,10 @@ class MTCS(BaseTCS):
             timeout=self.long_timeout,
         )
 
-        await asyncio.wait_for(
-            self._wait_hard_point_test_ok(hp=hp),
-            timeout=self.long_long_timeout,
-        )
+        try:
+            await self._wait_hard_point_test_ok(hp=hp)
+        except asyncio.TimeoutError:
+            raise RuntimeError("Timeout waiting for hardpoint test.")
 
     async def stop_m1m3_hard_point_test(self, hp: int) -> None:
         """Interrupt hard point test.

--- a/python/lsst/ts/observatory/control/mock/mtcs_async_mock.py
+++ b/python/lsst/ts/observatory/control/mock/mtcs_async_mock.py
@@ -209,6 +209,8 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
     async def setup_mtm1m3(self) -> None:
         """Augment MTM1M3."""
 
+        self.mtm1m3_cmd_enter_engineering_timeout = False
+
         m1m3_mocks = {
             "evt_detailedState.next.side_effect": self.mtm1m3_evt_detailed_state,
             "evt_detailedState.aget.side_effect": self.mtm1m3_evt_detailed_state,
@@ -424,6 +426,17 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
                 idl.enums.MTM1M3.DetailedState.PARKEDENGINEERING
             )
         )
+
+        # TODO (DM-39458): Remove this workaround.
+        # While running this command at the summit/production environment we
+        # have have experienced higher than average command timeouts. For the
+        # time being I implemented a workaround in
+        # MTCS.enter_m1m3_engineering_mode to ignore command timeouts. Once we
+        # figure out what is causing this issues (or we finish moving from DDS
+        # to Kafka and these issues, hopefully disappears) this work around
+        # should be removed.
+        if self.mtm1m3_cmd_enter_engineering_timeout:
+            raise asyncio.TimeoutError("Mock command timeout.")
 
     async def mtm1m3_cmd_exit_engineering(
         self, *args: typing.Any, **kwargs: typing.Any


### PR DESCRIPTION
This PR actually contains only work in support of Main Telescope activities that happened during the AT run.