### PR TITLE
Update ``MTCS.move_rotator`` with new ``wait_for_in_position`` option

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -11,6 +11,7 @@ v0.31.0
 
 * Add ``LSSTCam`` class to interface with the LSSTCam CSC using the ``BaseCamera`` interface.
 * In ``constants/latiss_constants.py``, update blue300lppm_qn1, holo4_003, and holo4_001 sweet spots.
+* Add new option to ``MTCS.move_rotator`` to allow the function to return before the rotator is in position.
 
 v0.30.5
 -------

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -1567,7 +1567,9 @@ class MTCS(BaseTCS):
             component_name="Camera Hexapod",
         )
 
-    async def move_rotator(self, position: float) -> None:
+    async def move_rotator(
+        self, position: float, wait_for_in_position: bool = True
+    ) -> None:
         """Move rotator to specified position and wait for movement to
         complete.
 
@@ -1575,17 +1577,23 @@ class MTCS(BaseTCS):
         ----------
         position : `float`
             Desired rotator position (deg).
+        wait_for_in_position : `bool`, optional
+            Wait for rotator to reach desired position before returning the
+            function? Default True.
         """
 
         await self.rem.mtrotator.cmd_move.set_start(
             position=position, timeout=self.long_timeout
         )
 
-        await self._handle_in_position(
-            in_position_event=self.rem.mtrotator.evt_inPosition,
-            timeout=self.long_long_timeout,
-            component_name="MTRotator",
-        )
+        if wait_for_in_position:
+            await self._handle_in_position(
+                in_position_event=self.rem.mtrotator.evt_inPosition,
+                timeout=self.long_long_timeout,
+                component_name="MTRotator",
+            )
+        else:
+            self.log.warning("Not waiting for rotator to reach desired position.")
 
     async def move_m2_hexapod(
         self,

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -1538,6 +1538,17 @@ class TestMTCS(MTCSAsyncMock):
             timeout=self.mtcs.long_long_timeout, flush=False
         )
 
+    async def test_move_rotator_without_wait(self) -> None:
+        position = 10.0
+
+        await self.mtcs.move_rotator(position=position, wait_for_in_position=False)
+
+        self.mtcs.rem.mtrotator.cmd_move.set_start.assert_awaited_with(
+            position=position, timeout=self.mtcs.long_timeout
+        )
+        self.mtcs.rem.mtrotator.evt_inPosition.aget.assert_not_awaited()
+        self.mtcs.rem.mtrotator.evt_inPosition.next.assert_not_awaited()
+
     async def test_move_camera_hexapod(self) -> None:
         hexapod_positions = dict([(axis, np.random.rand()) for axis in "xyzuv"])
 


### PR DESCRIPTION
The [DM-41081](https://jira.lsstcorp.org/browse/DM-41081) ticket requests a new SAL Script to send a command to the Rotator that moves it. It should also allow the script completion before the MTRotator reaches its final position. This functionality implemented here simplifies the SAL Script and avoids duplication. 