### PR TITLE
Tickets/dm 44670

### DIFF
--- a/doc/news/DM-44670.bugfix.rst
+++ b/doc/news/DM-44670.bugfix.rst
@@ -1,0 +1,1 @@
+Update ATCalSys so that the filter scans have the correct wavelength range.

--- a/doc/news/DM-44670.feature.1.rst
+++ b/doc/news/DM-44670.feature.1.rst
@@ -1,0 +1,1 @@
+Update ATCalSys.prepare_for_flat to call setup_electrometer.

--- a/doc/news/DM-44670.feature.2.rst
+++ b/doc/news/DM-44670.feature.2.rst
@@ -1,0 +1,1 @@
+Update atcalsys configuration such that the electrometer exposure time is similar to the camera exposure time and to include the additional electrometer configuration.

--- a/doc/news/DM-44670.feature.rst
+++ b/doc/news/DM-44670.feature.rst
@@ -1,0 +1,1 @@
+Update BaseCalSys.setup_electrometers to setup electrometer mode, range, and integration time from input parameters.

--- a/python/lsst/ts/observatory/control/auxtel/atcalsys.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcalsys.py
@@ -196,9 +196,16 @@ class ATCalsys(BaseCalsys):
             else utils.make_done_future()
         )
 
+        task_setup_electrometer = self.setup_electrometers(
+            mode=str(config_data["electrometer_mode"]),
+            range=float(config_data["electrometer_range"]),
+            integration_time=float(config_data["electrometer_integration_time"]),
+        )
+
         await asyncio.gather(
             task_setup_monochromator,
             task_setup_latiss,
+            task_setup_electrometer,
         )
 
     async def run_calibration_sequence(

--- a/python/lsst/ts/observatory/control/auxtel/atcalsys.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcalsys.py
@@ -233,7 +233,7 @@ class ATCalsys(BaseCalsys):
 
         calibration_type = getattr(CalibrationType, str(config_data["calib_type"]))
         if calibration_type == CalibrationType.WhiteLight:
-            calibration_wavelenghts = np.array([float(config_data["wavelength"])])
+            calibration_wavelengths = np.array([float(config_data["wavelength"])])
         else:
             wavelength = float(config_data["wavelength"])
             wavelength_width = float(config_data["wavelength_width"])
@@ -241,11 +241,13 @@ class ATCalsys(BaseCalsys):
             wavelength_start = wavelength - wavelength_width / 2.0
             wavelength_end = wavelength + wavelength_width / 2.0
 
-            calibration_wavelenghts = np.arange(
-                wavelength_start, wavelength_end, wavelength_resolution
+            calibration_wavelengths = np.arange(
+                wavelength_start,
+                wavelength_end + wavelength_resolution,
+                wavelength_resolution,
             )
 
-        for wavelength in calibration_wavelenghts:
+        for wavelength in calibration_wavelengths:
             self.log.debug(
                 f"Performing {calibration_type.name} calibration with {wavelength=}."
             )

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -13,7 +13,10 @@ scan_g:
   exit_slit: 5.0
   entrance_slit: 5.0
   fiber_spectrum_exposure_time: 0.5
-  electrometer_exposure_time: 1.0
+  electrometer_exposure_time: 15.0
+  electrometer_integration_time: 0.1
+  electrometer_mode: CURRENT
+  electrometer_range: -1
   exposure_times:
     - 15.0
 
@@ -29,7 +32,10 @@ scan_r:
   exit_slit: 5.0
   entrance_slit: 5.0
   fiber_spectrum_exposure_time: 0.5
-  electrometer_exposure_time: 1.0
+  electrometer_exposure_time: 15.0
+  electrometer_integration_time: 0.1
+  electrometer_mode: CURRENT
+  electrometer_range: -1
   exposure_times:
     - 15.0
 
@@ -43,7 +49,10 @@ at_whitelight_r:
   exit_slit: 5.0
   entrance_slit: 5.0
   fiber_spectrum_exposure_time: 3.0
-  electrometer_exposure_time: 1.0
+  electrometer_exposure_time: 6.0
+  electrometer_integration_time: 0.1
+  electrometer_mode: CURRENT
+  electrometer_range: -1
   exposure_times:
     - 6.0
     - 6.0

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -26,7 +26,7 @@ scan_r:
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
   wavelength: 625.0
-  wavelength_width: 150
+  wavelength_width: 250
   wavelength_resolution: 5.0
   monochromator_grating: RED
   exit_slit: 5.0

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -255,7 +255,7 @@ class TestATCalsys(RemoteGroupAsyncMock):
         assert "sequence_name" in calibration_summary
         assert calibration_summary["sequence_name"] == "scan_r"
         assert "steps" in calibration_summary
-        assert len(calibration_summary["steps"]) == 30
+        assert len(calibration_summary["steps"]) == 51
         assert (
             len(calibration_summary["steps"][0]["latiss_exposure_info"])
             == len(config_data["exposure_times"]) * 2

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -87,7 +87,13 @@ class TestATCalsys(RemoteGroupAsyncMock):
 
     async def test_setup_electrometers(self) -> None:
 
-        await self.atcalsys.setup_electrometers()
+        config_data = self.atcalsys.get_calibration_configuration("at_whitelight_r")
+
+        await self.atcalsys.setup_electrometers(
+            mode=str(config_data["electrometer_mode"]),
+            range=float(config_data["electrometer_range"]),
+            integration_time=float(config_data["electrometer_integration_time"]),
+        )
 
         self.atcalsys.electrometer.cmd_performZeroCalib.start.assert_awaited_with(
             timeout=self.atcalsys.long_timeout

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -242,14 +242,14 @@ class TestATCalsys(RemoteGroupAsyncMock):
         wavelength_start = wavelength - wavelength_width / 2.0
         wavelength_end = wavelength + wavelength_width / 2.0
 
-        calibration_wavelenghts = np.arange(
+        calibration_wavelengths = np.arange(
             wavelength_start, wavelength_end, wavelength_resolution
         )
         expected_change_wavelegths_calls = [
             unittest.mock.call(
                 wavelength=wavelength, timeout=self.atcalsys.long_long_timeout
             )
-            for wavelength in calibration_wavelenghts
+            for wavelength in calibration_wavelengths
         ]
 
         assert "sequence_name" in calibration_summary


### PR DESCRIPTION
ATCalSys updated so that (1) the filter scans have the correct wavelength range, (2) that setup_electrometers takes inputs from the config file about the electrometer mode, range, and integration time, and (3) there is only one electrometer scan per exposure.