### PR TITLE
adding calculate optimized exposure times

### DIFF
--- a/doc/news/DM-44361.feature.rst
+++ b/doc/news/DM-44361.feature.rst
@@ -1,0 +1,1 @@
+Added in optimized exposure times calculations for the electrometer and fiberspectrograph. This required some changes to the configuration file.

--- a/python/lsst/ts/observatory/control/auxtel/atcalsys.py
+++ b/python/lsst/ts/observatory/control/auxtel/atcalsys.py
@@ -72,6 +72,22 @@ class ATCalsysUsages(Usages):
 
 @dataclass
 class ATCalsysExposure:
+    """Store Exposure information for ATCalsys.
+
+    Attributes
+    ----------
+    wavelength : float
+        Wavelength of the calibration exposure, in nm.
+    camera : float
+        Camera exposure time, in sec.
+    fiberspectrograph : float | None
+        Fiber spectrograph exposure time, in sec.
+        If None, skip fiber spectrograph acquisition.
+    electrometer : float | None
+        Electrometer exposure time, in sec.
+        If None, skip electrometer acquisition.
+    """
+
     wavelength: float
     camera: float
     fiberspectrograph: float | None
@@ -232,13 +248,14 @@ class ATCalsys(BaseCalsys):
 
         Returns
         -------
-        exposure_list : `array`
-            List of exposure information, including wavelength and camera,
-            fiberspectrograph and electrometer exposure times.
+        exposure_list : `list`[ATCalsysExposure]
+            List of exposure information saved in the dataclass
+            ATCalsysExposure. Each exposure includes wavelength
+            and camera, fiberspectrograph and electrometer exposure times.
 
         """
 
-        exposures = []
+        exposures: list[ATCalsysExposure] = []
         for wavelength in wavelengths:
             electrometer_exptimes = await self._calculate_electrometer_exposure_times(
                 exptimes=config_data["exposure_times"],

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -12,11 +12,11 @@ scan_g:
   monochromator_grating: RED
   exit_slit: 5.0
   entrance_slit: 5.0
-  fiber_spectrum_exposure_time: 0.5
-  electrometer_exposure_time: 15.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1
+  use_fiberspectrograph: true
+  use_electrometer: true
   exposure_times:
     - 15.0
 
@@ -31,11 +31,11 @@ scan_r:
   monochromator_grating: RED
   exit_slit: 5.0
   entrance_slit: 5.0
-  fiber_spectrum_exposure_time: 0.5
-  electrometer_exposure_time: 15.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1
+  use_fiberspectrograph: true
+  use_electrometer: true
   exposure_times:
     - 15.0
 
@@ -48,11 +48,11 @@ at_whitelight_r:
   monochromator_grating: RED 
   exit_slit: 5.0
   entrance_slit: 5.0
-  fiber_spectrum_exposure_time: 3.0
-  electrometer_exposure_time: 6.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1
+  use_fiberspectrograph: true
+  use_electrometer: true
   exposure_times:
     - 6.0
     - 6.0

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -206,6 +206,7 @@ class TestATCalsys(RemoteGroupAsyncMock):
         assert "sequence_name" in calibration_summary
         assert calibration_summary["sequence_name"] == "at_whitelight_r"
         assert "steps" in calibration_summary
+        self.log.debug("number of steps:", len(calibration_summary["steps"]))
         assert len(calibration_summary["steps"]) == 1
         assert len(calibration_summary["steps"][0]["latiss_exposure_info"]) == len(
             config_data["exposure_times"]

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -207,10 +207,7 @@ class TestATCalsys(RemoteGroupAsyncMock):
         assert calibration_summary["sequence_name"] == "at_whitelight_r"
         assert "steps" in calibration_summary
         self.log.debug("number of steps:", len(calibration_summary["steps"]))
-        assert len(calibration_summary["steps"]) == 21
-        assert len(calibration_summary["steps"][0]["latiss_exposure_info"]) == len(
-            config_data["exposure_times"]
-        )
+        assert len(calibration_summary["steps"]) == len(config_data["exposure_times"])
         for latiss_exposure_info in calibration_summary["steps"][0][
             "latiss_exposure_info"
         ].values():

--- a/tests/auxtel/test_atcalsys.py
+++ b/tests/auxtel/test_atcalsys.py
@@ -207,7 +207,7 @@ class TestATCalsys(RemoteGroupAsyncMock):
         assert calibration_summary["sequence_name"] == "at_whitelight_r"
         assert "steps" in calibration_summary
         self.log.debug("number of steps:", len(calibration_summary["steps"]))
-        assert len(calibration_summary["steps"]) == 1
+        assert len(calibration_summary["steps"]) == 21
         assert len(calibration_summary["steps"][0]["latiss_exposure_info"]) == len(
             config_data["exposure_times"]
         )


### PR DESCRIPTION
This new function returns an exposure list with wavelength and camera, electrometer and fiberspectrograph exposure times. It is called in `run_calibration_sequence`. The main change to this function is that instead of looping through wavelength, it loops through exposure. This does change what is included in a "step", but I think for how we will be running sequences on AuxTel that is ok. 

There are changes to the configuration file `atcalsys.yaml`:
* Removal of exptime for electrometer and fiber spectrograph
* Addition of `use_fiberspectrograph` and `use_electrometer`

And finally, removed the use of `exposures_done` for both electrometer and fiber spectrograph. We will not want these exposures to just repeat. For one, if the electrometer exposure repeats it will significantly delay the sequence due to readout times and often won't give us useful information. Also, generally, we only want one fiber spectrograph exposure. If we want to continuously take them several times during an exposure, we should add in an explicit number.