### PR TITLE
DM-45975: update grating for whitelight in PTC curves

### DIFF
--- a/doc/news/DM-45975.bugfix.rst
+++ b/doc/news/DM-45975.bugfix.rst
@@ -1,0 +1,1 @@
+Changed grating from Blue to Mirror for PTC curves to align with updated hardware configuration and xml

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -45,7 +45,7 @@ at_whitelight_r:
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1  
   wavelength: 500.0
-  monochromator_grating: RED 
+  monochromator_grating: MIRROR 
   exit_slit: 5.0
   entrance_slit: 5.0
   electrometer_integration_time: 0.1
@@ -84,7 +84,7 @@ ptc_1:
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
   wavelength: 500.0
-  monochromator_grating: BLUE
+  monochromator_grating: MIRROR
   exit_slit: 7.0
   entrance_slit: 7.0
   electrometer_integration_time: 0.1
@@ -168,7 +168,7 @@ ptc_2:
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
   wavelength: 500.0
-  monochromator_grating: BLUE
+  monochromator_grating: MIRROR
   exit_slit: 7.0
   entrance_slit: 7.0
   electrometer_integration_time: 0.1
@@ -251,7 +251,7 @@ ptc_3:
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
   wavelength: 500.0
-  monochromator_grating: BLUE
+  monochromator_grating: MIRROR
   exit_slit: 7.0
   entrance_slit: 7.0
   electrometer_integration_time: 0.1


### PR DESCRIPTION
We updated the Monochromator xml enumeration (DM-45474) so that it correctly aligns with the gratings. I have updated the configuration for the PTC curves so that it calls on MIRROR instead of the BLUE grating.