### PR TITLE
tickets/DM-45609

### DIFF
--- a/doc/news/DM-45609.feature.rst
+++ b/doc/news/DM-45609.feature.rst
@@ -1,0 +1,1 @@
+Implement dome parking in MTCS.

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -32,6 +32,7 @@ from lsst.ts import idl, utils
 from lsst.ts.idl.enums import MTM1M3, MTM2
 from lsst.ts.observatory.control.mock.mtcs_async_mock import MTCSAsyncMock
 from lsst.ts.observatory.control.utils import RotType
+from lsst.ts.xml.enums import MTDome
 
 
 class TestMTCS(MTCSAsyncMock):
@@ -763,6 +764,23 @@ class TestMTCS(MTCSAsyncMock):
             dy=y_offset * self.mtcs.plate_scale,
             num=0,
         )
+
+    async def test_park_dome(self) -> None:
+        await self.mtcs.enable()
+        await self.mtcs.assert_all_enabled()
+
+        # Call the park_dome method
+        await self.mtcs.park_dome()
+
+        az_motion = await self.mtcs.rem.mtdome.evt_azMotion.aget(
+            timeout=self.mtcs.park_dome_timeout
+        )
+
+        # Check the state of the azMotion event
+        assert (
+            az_motion.state == MTDome.MotionState.PARKED
+        ), "Dome did not reach the PARKED state."
+        assert az_motion.inPosition, "Dome is not in position."
 
     async def test_slew_dome_to(self) -> None:
         az = 90.0


### PR DESCRIPTION
- Add the `park_dome` method in `MTCS` to park the dome. This includes:
  - Ensuring the dome is enabled before initiating the park sequence.
  - Commanding the dome to park and waiting for the dome's azimuth motion state to reach `PARKED`.
  - Added a polling mechanism to periodically check the dome's `azMotion` event until it reaches the `PARKED` state or a timeout occurs.
  - Raised an error if the dome fails to park within the timeout window.

- Updated the `MTCSAsyncMock` class to simulate dome parking behavior:
  - Mocked the `evt_azMotion` event to simulate the dome reaching the `PARKED` state with `inPosition=True`.
  - Added mocking for the `cmd_park` command to simulate a dome park action.

- Added a new unit test `test_park_dome`
  - Asserted that the `evt_azMotion` event is awaited and reaches the `PARKED` state with `inPosition=True`.