### PR TITLE
DM-46167: added optical configuration to enums

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Install
         run: |
+          $CONDA/bin/conda config --set solver classic
           $CONDA/bin/conda install -c lsstts -c conda-forge pre-commit ts-pre-commit-config python=3.11 -y
           $CONDA/bin/conda install -c conda-forge pre-commit -y
           $CONDA/bin/generate_pre_commit_conf --skip-pre-commit-install

--- a/doc/news/DM-46167.misc.rst
+++ b/doc/news/DM-46167.misc.rst
@@ -1,0 +1,1 @@
+Temporary addition of Tunable Laser Optical Configuration into enum while xml prepared for deployment

--- a/python/lsst/ts/observatory/control/utils/enums.py
+++ b/python/lsst/ts/observatory/control/utils/enums.py
@@ -18,7 +18,14 @@
 #
 # You should have received a copy of the GNU General Public License
 
-__all__ = ["RotType", "InstrumentFocus", "ClosedLoopMode", "DOFName", "CalibrationType"]
+__all__ = [
+    "RotType",
+    "InstrumentFocus",
+    "ClosedLoopMode",
+    "DOFName",
+    "CalibrationType",
+    "LaserOpticalConfiguration",
+]
 
 import enum
 

--- a/python/lsst/ts/observatory/control/utils/enums.py
+++ b/python/lsst/ts/observatory/control/utils/enums.py
@@ -151,3 +151,21 @@ class CalibrationType(enum.IntEnum):
 
     WhiteLight = 1
     Mono = 2
+
+
+# TODO: (DM-46168) Revert workaround for TunableLaser XML changes
+class LaserOpticalConfiguration(enum.StrEnum):
+    """Configuration of the optical output"""
+
+    SCU = "SCU"
+    """Pass the beam straight-through the SCU."""
+    F1_SCU = "F1 SCU"
+    """Direct the beam through the F1 after passing through the SCU."""
+    F2_SCU = "F2 SCU"
+    """Direct the beam through the F2 after passing through the SCU."""
+    NO_SCU = "No SCU"
+    """Pass the beam straight-through."""
+    F1_NO_SCU = "F1 No SCU"
+    """Pass the beam to F1 output."""
+    F2_NO_SCU = "F2 No SCU"
+    """Pass the beam to F2 output."""

--- a/python/lsst/ts/observatory/control/utils/enums.py
+++ b/python/lsst/ts/observatory/control/utils/enums.py
@@ -162,17 +162,29 @@ class CalibrationType(enum.IntEnum):
 
 # TODO: (DM-46168) Revert workaround for TunableLaser XML changes
 class LaserOpticalConfiguration(enum.StrEnum):
-    """Configuration of the optical output"""
+    """Configuration of the optical output
+
+    Attributes
+    ----------
+
+    SCU: `str`
+        Pass the beam straight-through the SCU.
+    F1_SCU: `str`
+        Direct the beam through the F1 after passing through the SCU.
+    F2_SCU: `str`
+        Direct the beam through the F2 after passing through the SCU.
+    NO_SCU: `str`
+        Pass the beam straight-through.
+    F1_NO_SCU: `str`
+        Pass the beam to F1 output.
+    F2_NO_SCU: `str`
+        Pass the beam to F2 output.
+
+    """
 
     SCU = "SCU"
-    """Pass the beam straight-through the SCU."""
     F1_SCU = "F1 SCU"
-    """Direct the beam through the F1 after passing through the SCU."""
     F2_SCU = "F2 SCU"
-    """Direct the beam through the F2 after passing through the SCU."""
     NO_SCU = "No SCU"
-    """Pass the beam straight-through."""
     F1_NO_SCU = "F1 No SCU"
-    """Pass the beam to F1 output."""
     F2_NO_SCU = "F2 No SCU"
-    """Pass the beam to F2 output."""


### PR DESCRIPTION
While we wait for the XML changes to be made, we will include the Tunable Laser Optical Configuration here. It will be removed when the xml has been deployed.