### PR TITLE
Tickets/DM-46983: Use `DefaultingValidator` output to render the calibrations configuration in `BaseCalsys`, new defaults values and cleanups

### DIFF
--- a/doc/news/DM-46983.bugfix.rst
+++ b/doc/news/DM-46983.bugfix.rst
@@ -1,0 +1,1 @@
+In ``BaseCalsys.load_calibration_config_file``, fix schema validation to update configurations with default values applied by ``salobj.DefaultingValidator``.

--- a/doc/news/DM-46983.feature.1.rst
+++ b/doc/news/DM-46983.feature.1.rst
@@ -1,0 +1,1 @@
+Add new default values for ``ATCalsys`` configurations in ``atcalsys_schema.yaml``.

--- a/doc/news/DM-46983.feature.2.rst
+++ b/doc/news/DM-46983.feature.2.rst
@@ -1,0 +1,1 @@
+Cleanup of ``ATCalsys`` configuration file ``atcalsys.yaml`` by removing attributes that use default values.

--- a/doc/news/DM-46983.feature.3.rst
+++ b/doc/news/DM-46983.feature.3.rst
@@ -1,0 +1,2 @@
+Add new default values for ``MTCalsys`` configurations in ``mtcalsys_schema.yaml``.
+

--- a/doc/news/DM-46983.feature.4.rst
+++ b/doc/news/DM-46983.feature.4.rst
@@ -1,0 +1,2 @@
+Cleanup of ``MTCalsys`` configuration file ``mtcalsys.yaml`` by removing attributes that use default values.
+

--- a/python/lsst/ts/observatory/control/base_calsys.py
+++ b/python/lsst/ts/observatory/control/base_calsys.py
@@ -240,7 +240,9 @@ class BaseCalsys(RemoteGroup, metaclass=abc.ABCMeta):
         validation_errors = ""
         for item in self.calibration_config:
             try:
-                config_validator.validate(self.calibration_config[item])
+                self.calibration_config[item] = config_validator.validate(
+                    self.calibration_config[item]
+                )
             except jsonschema.ValidationError as e:
                 validation_errors += f"\t{item} failed validation: {e.message}.\n"
                 self.log.exception(f"{item} failed validation.")

--- a/python/lsst/ts/observatory/control/base_calsys.py
+++ b/python/lsst/ts/observatory/control/base_calsys.py
@@ -238,7 +238,9 @@ class BaseCalsys(RemoteGroup, metaclass=abc.ABCMeta):
             config_validator = salobj.DefaultingValidator(schema=yaml.safe_load(f))
 
         validation_errors = ""
+        log_defaults = ""
         for item in self.calibration_config:
+            config_original = dict(self.calibration_config[item])
             try:
                 self.calibration_config[item] = config_validator.validate(
                     self.calibration_config[item]
@@ -246,10 +248,17 @@ class BaseCalsys(RemoteGroup, metaclass=abc.ABCMeta):
             except jsonschema.ValidationError as e:
                 validation_errors += f"\t{item} failed validation: {e.message}.\n"
                 self.log.exception(f"{item} failed validation.")
+            config_with_defaults = self.calibration_config[item]
+            defaulted_attributes = set(config_with_defaults) - set(config_original)
+            log_defaults += f"\n{item}:\n" + "\n".join(
+                f"    {attr}: {config_with_defaults[attr]}"
+                for attr in defaulted_attributes
+            )
         if validation_errors:
             raise RuntimeError(
                 f"Failed schema validation:\n{validation_errors}Check logs for more information."
             )
+        self.log.debug(f"\n=== Applied Default Values ===\n{log_defaults}\n")
 
     def get_calibration_configuration(self, name: str) -> dict[str, typing.Any]:
         """Returns the configuration attributes given a configuration

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -3,55 +3,35 @@
 
 scan_g:
   calib_type: Mono
-  use_camera: true
   atspec_filter: SDSSg_65mm
   atspec_grating: empty_1
   wavelength: 475.0
   wavelength_width: 250
-  wavelength_resolution: 5.0
   monochromator_grating: RED
   exit_slit: 5.0
   entrance_slit: 5.0
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
-  use_fiberspectrograph: true
-  use_electrometer: true
   exposure_times:
     - 15.0
 
 scan_r:
   calib_type: Mono
-  use_camera: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
   wavelength: 625.0
   wavelength_width: 250
-  wavelength_resolution: 5.0
   monochromator_grating: RED
   exit_slit: 5.0
   entrance_slit: 5.0
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
-  use_fiberspectrograph: true
-  use_electrometer: true
   exposure_times:
     - 15.0
 
 at_whitelight_r:
   calib_type: WhiteLight
-  use_camera: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1  
   monochromator_grating: MIRROR 
   exit_slit: 5.0
   entrance_slit: 5.0
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
-  use_fiberspectrograph: true
-  use_electrometer: true
   exposure_times:
     - 6.0
     - 6.0
@@ -77,14 +57,9 @@ at_whitelight_r:
 
 ptc_1:
   calib_type: WhiteLight
-  use_camera: true
   use_fiberspectrograph: false 
-  use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 14.40
     - 14.40
@@ -157,14 +132,9 @@ ptc_1:
 
 ptc_2:
   calib_type: WhiteLight
-  use_camera: true
   use_fiberspectrograph: false 
-  use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.35
     - 15.35
@@ -236,14 +206,9 @@ ptc_2:
 
 ptc_3:
   calib_type: WhiteLight
-  use_camera: true
   use_fiberspectrograph: false 
-  use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 0.52
     - 0.52

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -44,7 +44,6 @@ at_whitelight_r:
   use_camera: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1  
-  wavelength: 500.0
   monochromator_grating: MIRROR 
   exit_slit: 5.0
   entrance_slit: 5.0
@@ -83,10 +82,6 @@ ptc_1:
   use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  wavelength: 500.0
-  monochromator_grating: null
-  exit_slit: 7.0
-  entrance_slit: 7.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1
@@ -167,10 +162,6 @@ ptc_2:
   use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  wavelength: 500.0
-  monochromator_grating: null
-  exit_slit: 7.0
-  entrance_slit: 7.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1
@@ -250,10 +241,6 @@ ptc_3:
   use_electrometer: true
   atspec_filter: SDSSr_65mm
   atspec_grating: empty_1
-  wavelength: 500.0
-  monochromator_grating: null
-  exit_slit: 7.0
-  entrance_slit: 7.0
   electrometer_integration_time: 0.1
   electrometer_mode: CURRENT
   electrometer_range: -1

--- a/python/lsst/ts/observatory/control/data/atcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys.yaml
@@ -4,7 +4,6 @@
 scan_g:
   calib_type: Mono
   atspec_filter: SDSSg_65mm
-  atspec_grating: empty_1
   wavelength: 475.0
   wavelength_width: 250
   monochromator_grating: RED
@@ -15,8 +14,6 @@ scan_g:
 
 scan_r:
   calib_type: Mono
-  atspec_filter: SDSSr_65mm
-  atspec_grating: empty_1
   wavelength: 625.0
   wavelength_width: 250
   monochromator_grating: RED
@@ -26,8 +23,6 @@ scan_r:
     - 15.0
 
 at_whitelight_r:
-  calib_type: WhiteLight
-  atspec_filter: SDSSr_65mm
   atspec_grating: empty_1  
   monochromator_grating: MIRROR 
   exit_slit: 5.0
@@ -56,10 +51,7 @@ at_whitelight_r:
     - 6.0
 
 ptc_1:
-  calib_type: WhiteLight
   use_fiberspectrograph: false 
-  atspec_filter: SDSSr_65mm
-  atspec_grating: empty_1
   exposure_times:
     - 14.40
     - 14.40
@@ -131,10 +123,7 @@ ptc_1:
     - 0.93
 
 ptc_2:
-  calib_type: WhiteLight
   use_fiberspectrograph: false 
-  atspec_filter: SDSSr_65mm
-  atspec_grating: empty_1
   exposure_times:
     - 15.35
     - 15.35
@@ -205,10 +194,7 @@ ptc_2:
 
 
 ptc_3:
-  calib_type: WhiteLight
   use_fiberspectrograph: false 
-  atspec_filter: SDSSr_65mm
-  atspec_grating: empty_1
   exposure_times:
     - 0.52
     - 0.52

--- a/python/lsst/ts/observatory/control/data/atcalsys_schema.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys_schema.yaml
@@ -14,6 +14,7 @@ properties:
   use_camera:
     description: Indicates whether the operation requires a camera.
     type: boolean
+    default: true
   atspec_filter:
     description: Name of the filter to select for the spectrograph.
     type: string
@@ -32,6 +33,7 @@ properties:
       monochromator for the flat-field calibration sequence when using
       monochromatic light.
     type: number
+    default: 0.0
   wavelength_resolution:
     description: >-
       Optional. When using a monochromatic light source, it defines the
@@ -39,6 +41,7 @@ properties:
       defined by `wavelength_width` and is centered around the `wavelength`
       attribute.
     type: number
+    default: 5.0
   monochromator_grating:
     description: >-
       Select the grating of the monochromator that will be in the path of
@@ -75,6 +78,7 @@ properties:
       (default) integration = 1PLC; High Accuracy integration=10PLC. Here the
       integration is set in seconds.
     type: number
+    default: 0.1
   electrometer_mode:
     description: >-
       Set electrometer to use different modes. The units recorded will be Amps
@@ -86,6 +90,7 @@ properties:
       - CHARGE
       - VOLTAGE
       - RESISTANCE
+    default: CURRENT
   electrometer_range:
     description: >-
       Set measurement range, which effects the accuracy of measurements and the
@@ -99,14 +104,17 @@ properties:
       from 0 to 21e-3 Amps, Resistance from 0 to 100e18 Ohms, Charge from 0 to
       +2.1e-6 Coulombs.
     type: number
+    default: -1
   use_fiberspectrograph:
     description: >-
       Identifies if the fiberspectrograph will be used in the exposure.
     type: boolean
+    default: true
   use_electrometer:
     description: >-
       Identifies if the electrometer will be used in the exposure.
     type: boolean
+    default: true
   exposure_times:
     description: >-
       List of Camera exposure times, in secs

--- a/python/lsst/ts/observatory/control/data/atcalsys_schema.yaml
+++ b/python/lsst/ts/observatory/control/data/atcalsys_schema.yaml
@@ -11,6 +11,7 @@ properties:
     enum:
       - Mono
       - WhiteLight
+    default: WhiteLight
   use_camera:
     description: Indicates whether the operation requires a camera.
     type: boolean
@@ -18,9 +19,11 @@ properties:
   atspec_filter:
     description: Name of the filter to select for the spectrograph.
     type: string
+    default: SDSSr_65mm
   atspec_grating:
     description: Name of the grating to select for the spectrograph.
     type: string
+    default: empty_1
   wavelength:
     description: >-
       Center wavelength value in nm, used for configuring the monochromator

--- a/python/lsst/ts/observatory/control/data/mtcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/mtcalsys.yaml
@@ -2,7 +2,6 @@
 # Created 2024-07-15
 
 whitelight_u:
-  calib_type: WhiteLight
   mtcamera_filter: u
   led_name: 
     - M385L3
@@ -13,7 +12,6 @@ whitelight_u:
     - 15.0
 
 whitelight_g:
-  calib_type: WhiteLight
   mtcamera_filter: g
   led_name:
     - M455L4
@@ -25,8 +23,6 @@ whitelight_g:
     - 15.0
 
 whitelight_r:
-  calib_type: WhiteLight
-  mtcamera_filter: r
   led_name:
     - M565L3
     - M660L4
@@ -37,7 +33,6 @@ whitelight_r:
     - 15.0
 
 whitelight_i:
-  calib_type: WhiteLight
   mtcamera_filter: i
   led_name:
     - M730L5
@@ -49,7 +44,6 @@ whitelight_i:
     - 15.0
 
 whitelight_z:
-  calib_type: WhiteLight
   mtcamera_filter: z
   led_name:
     - M850L3
@@ -61,21 +55,15 @@ whitelight_z:
     - 15.0
 
 whitelight_y:
-  calib_type: WhiteLight
   mtcamera_filter: y
   led_name:
     - M970L4
   wavelength: 970.0
-  led_location: 174.91
-  led_focus: 15.380
   exposure_times:
     - 15.0
 
 scan_r:
   calib_type: Mono
-  mtcamera_filter: r
-  led_location: 174.91
-  led_focus: 15.380
   wavelength: 625.0
   wavelength_width: 250
   wavelength_resolution: 5.0

--- a/python/lsst/ts/observatory/control/data/mtcalsys.yaml
+++ b/python/lsst/ts/observatory/control/data/mtcalsys.yaml
@@ -3,25 +3,17 @@
 
 whitelight_u:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: u
   led_name: 
     - M385L3
   wavelength: 385.0
   led_location: 210.21
   led_focus: 50.68
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 whitelight_g:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: g
   led_name:
     - M455L4
@@ -29,18 +21,11 @@ whitelight_g:
   wavelength: 480.0
   led_location: 9.15
   led_focus: 17.029
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 whitelight_r:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: r
   led_name:
     - M565L3
@@ -48,18 +33,11 @@ whitelight_r:
   wavelength: 612.5
   led_location: 70.40
   led_focus: 16.279
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 whitelight_i:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: i
   led_name:
     - M730L5
@@ -67,18 +45,11 @@ whitelight_i:
   wavelength: 755.0
   led_location: 237.36
   led_focus: 15.829
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 whitelight_z:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: z
   led_name:
     - M850L3
@@ -86,47 +57,27 @@ whitelight_z:
   wavelength: 895.0
   led_location: 299.034
   led_focus: 15.505
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 whitelight_y:
   calib_type: WhiteLight
-  use_camera: true
   mtcamera_filter: y
   led_name:
     - M970L4
   wavelength: 970.0
   led_location: 174.91
   led_focus: 15.380
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0
 
 scan_r:
   calib_type: Mono
-  use_camera: true
   mtcamera_filter: r
   led_location: 174.91
   led_focus: 15.380
   wavelength: 625.0
   wavelength_width: 250
   wavelength_resolution: 5.0
-  use_electrometer: true
-  use_fiberspectrograph_red: true
-  use_fiberspectrograph_blue: true
-  electrometer_integration_time: 0.1
-  electrometer_mode: CURRENT
-  electrometer_range: -1
   exposure_times:
     - 15.0

--- a/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
+++ b/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
@@ -40,6 +40,7 @@ properties:
     description: >-
       Center wavelength value in nm, used for configuring the Tunable Laser
     type: number
+    default: 400.0
   wavelength_width:
     description: >-
       Optional. Defines the width of the wavelength scan range to configure the

--- a/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
+++ b/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
@@ -11,6 +11,7 @@ properties:
     enum:
       - Mono
       - WhiteLight
+    default: WhiteLight
   use_camera:
     description: Indicates whether the operation requires a camera.
     type: boolean
@@ -18,6 +19,7 @@ properties:
   mtcamera_filter:
     description: The filter name to install.
     type: string
+    default: r
   led_name:
     description: List of LED serial numbers to be turned on.
     type: array
@@ -56,11 +58,13 @@ properties:
       Absolute distance to move the horizontal linear stage between LED
       modules, expressed in mm.
     type: number
+    default: 174.91
   led_focus:
     description: >-
       Absolute distance in nm for the horizontal linear stage to move a lens to
       focus the laser light from the fiber.
     type: number
+    default: 15.380
   use_electrometer:
     description: Identifies if the electrometer will be used in the exposure.
     type: boolean

--- a/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
+++ b/python/lsst/ts/observatory/control/data/mtcalsys_schema.yaml
@@ -14,6 +14,7 @@ properties:
   use_camera:
     description: Indicates whether the operation requires a camera.
     type: boolean
+    default: true
   mtcamera_filter:
     description: The filter name to install.
     type: string
@@ -63,16 +64,19 @@ properties:
   use_electrometer:
     description: Identifies if the electrometer will be used in the exposure.
     type: boolean
+    default: true
   use_fiberspectrograph_red:
     description: >-
       Identifies if the fiberspectrograph for red color will be used in the
       exposure.
     type: boolean
+    default: true
   use_fiberspectrograph_blue:
     description: >-
       Identifies if the fiberspectrograph for blue color will be used in the
       exposure.
     type: boolean
+    default: true
   electrometer_integration_time:
     description: >-
       Integration time in seconds (166.67e-6 to 200e-3) for each sample.
@@ -86,6 +90,7 @@ properties:
       (default) integration = 1PLC; High Accuracy integration=10PLC. Here the
       integration is set in seconds.
     type: number
+    default: 0.1
   electrometer_mode:
     description: >-
       Set electrometer to use different modes. The units recorded will be Amps
@@ -97,6 +102,7 @@ properties:
       - CHARGE
       - VOLTAGE
       - RESISTANCE
+    default: CURRENT
   electrometer_range:
     description: >-
       Set measurement range, which effects the accuracy of measurements and the
@@ -110,6 +116,7 @@ properties:
       from 0 to 21e-3 Amps, Resistance from 0 to 100e18 Ohms, Charge from 0 to
       +2.1e-6 Coulombs.
     type: number
+    default: -1
   exposure_times:
     description: List of Camera exposure times, in secs.
     type: array


### PR DESCRIPTION
- Fix bug: configurations are now updated with default values applied by `salobj.DefaultingValidator` in `BaseCalsys.load_calibration_config_file`.
- Add new default values to `atcalsys_schema.yaml` and `mtcalsys_schema.yaml`.
- Remove attributes from `atcalsys.yaml` and `mtcalsys.yaml` that use default values.