### PR TITLE
tickets/DM-46980: Implement dome homing in MTCS

### DIFF
--- a/doc/news/DM-46980.feature.rst
+++ b/doc/news/DM-46980.feature.rst
@@ -1,0 +1,1 @@
+Implement dome homing in ``MTCS``.

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -862,6 +862,8 @@ class MTCS(BaseTCS):
         target_az = self.home_dome_az - offset
         await self.slew_dome_to(target_az)
 
+        self.rem.mtdome.evt_azMotion.flush()
+
         await self.rem.mtdome.cmd_stop.set_start(
             engageBrakes=True,
             subSystemIds=MTDome.SubSystemId.AMCS,
@@ -872,7 +874,7 @@ class MTCS(BaseTCS):
         )
         while motion_state.state != MTDome.MotionState.STOPPED_BRAKED:
             motion_state = await self.rem.mtdome.evt_azMotion.next(
-                flush=False, timeout=self.fast_timeout
+                flush=False, timeout=self.long_long_timeout
             )
             self.log.debug(f"Motion state: {MTDome.MotionState(motion_state.state)!r}")
 

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -1029,6 +1029,8 @@ class TestMTCS(MTCSAsyncMock):
 
         offset = physical_az - self._mtdome_tel_azimuth.positionActual
 
+        await self.mtcs.enable()
+        await self.mtcs.assert_all_enabled()
         await self.mtcs.home_dome(physical_az)
 
         self.mtcs.rem.mtdome.evt_azMotion.flush.assert_called()
@@ -1036,13 +1038,15 @@ class TestMTCS(MTCSAsyncMock):
         self.mtcs.rem.mtdome.cmd_moveAz.set_start.assert_awaited_with(
             position=self.mtcs.home_dome_az - offset,
             velocity=0.0,
-            timeout=self.mtcs.park_dome_timeout,
+            timeout=self.mtcs.long_long_timeout,
         )
 
         assert self.mtcs.rem.mtdome.evt_azMotion.inPosition
 
         self.mtcs.rem.mtdome.cmd_stop.set_start.assert_awaited_with(
-            engageBrakes=True, timeout=self.mtcs.long_long_timeout
+            engageBrakes=True,
+            subSystemIds=MTDome.SubSystemId.AMCS,
+            timeout=self.mtcs.long_long_timeout,
         )
 
         self.mtcs.rem.mtdome.cmd_setZeroAz.start.assert_awaited_with(


### PR DESCRIPTION
This implementation encodes the manual procedure to home the MTDome azimuth including the case where the reference azimuth position is lost, and the encoders are not reading the real position of the dome azimuth.