### PR TITLE
DM-47414: In base_camera.py, remove support for splitting guider ROI …

### DIFF
--- a/doc/news/DM-47414.removal.rst
+++ b/doc/news/DM-47414.removal.rst
@@ -1,0 +1,5 @@
+::::::::::::::
+doc/news/DM-47414.removal.rst
+::::::::::::::
+In base_camera.py, remove support for splitting guider ROI specs into multiple part. Size limit no longer exists.
+

--- a/doc/news/DM-47414.removal.rst
+++ b/doc/news/DM-47414.removal.rst
@@ -1,5 +1,1 @@
-::::::::::::::
-doc/news/DM-47414.removal.rst
-::::::::::::::
 In base_camera.py, remove support for splitting guider ROI specs into multiple part. Size limit no longer exists.
-

--- a/python/lsst/ts/observatory/control/base_camera.py
+++ b/python/lsst/ts/observatory/control/base_camera.py
@@ -1148,7 +1148,6 @@ class BaseCamera(RemoteGroup, metaclass=abc.ABCMeta):
         roi = roi_spec_dict.pop("roi")
         roi_spec_dict.update(roi)
         roi_spec_json = json.dumps(roi_spec_dict, separators=(",", ":"))
-        self.log.info(f"ROISpec(len:{len(roi_spec_json)}) fits in one command.")
         await self.camera.cmd_initGuiders.set_start(
             roiSpec=roi_spec_json,
             timeout=self.long_timeout,

--- a/tests/maintel/test_lsstcam.py
+++ b/tests/maintel/test_lsstcam.py
@@ -338,7 +338,12 @@ class TestLSSTCam(BaseCameraAsyncMock):
 
         roi_spec = ROISpec(
             common=roi_common,
-            roi=dict(R40_SG0=roi),
+            roi=dict(
+                R40_SG0=roi,
+                R01_SG0=roi,
+                R02_SG0=roi,
+                R03_SG0=roi,
+            ),
         )
 
         # initialize guiders


### PR DESCRIPTION
…specs into multiple part. Size limit no longer exists.