### PR TITLE
Tickets/dm-47795

### DIFF
--- a/doc/news/DM-47795.bugfix.rst
+++ b/doc/news/DM-47795.bugfix.rst
@@ -1,0 +1,1 @@
+IN ``mtcs.py``, wait for both primary and secondary bump tests to finish to avoid a race condition where the last actuator has its test cancelled due to exiting engineering mode on M1M3.

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -1447,6 +1447,14 @@ class MTCS(BaseTCS):
             done = (primary_status == MTM1M3.BumpTest.PASSED if primary else True) and (
                 secondary_status == MTM1M3.BumpTest.PASSED if secondary else True
             )
+            primary_testing = (
+                primary_status not in {MTM1M3.BumpTest.PASSED, MTM1M3.BumpTest.FAILED}
+                and primary
+            )
+            secondary_testing = (
+                secondary_status not in {MTM1M3.BumpTest.PASSED, MTM1M3.BumpTest.FAILED}
+                and secondary
+            )
 
             if done:
                 self.log.info(
@@ -1454,11 +1462,15 @@ class MTCS(BaseTCS):
                     f"{primary_status!r}[{primary}], {secondary_status!r}[{secondary}]"
                 )
                 return
-            elif primary and primary_status == MTM1M3.BumpTest.FAILED:
+            elif (
+                primary and primary_status == MTM1M3.BumpTest.FAILED
+            ) and not secondary_testing:
                 raise RuntimeError(
                     f"Primary bump test failed for actuator {actuator_id}."
                 )
-            elif secondary and secondary_status == MTM1M3.BumpTest.FAILED:
+            elif (
+                secondary and secondary_status == MTM1M3.BumpTest.FAILED
+            ) and not primary_testing:
                 raise RuntimeError(
                     f"Secondary bump test failed for actuator {actuator_id}."
                 )

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -1708,19 +1708,6 @@ class TestMTCS(MTCSAsyncMock):
         ) = await self.mtcs.get_m1m3_bump_test_status(actuator_id=actuator_id)
 
         assert primary_status == idl.enums.MTM1M3.BumpTest.FAILED
-        assert secondary_status != idl.enums.MTM1M3.BumpTest.FAILED
-
-        with pytest.raises(RuntimeError):
-            await self.mtcs._wait_bump_test_ok(
-                actuator_id=actuator_id, primary=False, secondary=True
-            )
-
-        (
-            primary_status,
-            secondary_status,
-        ) = await self.mtcs.get_m1m3_bump_test_status(actuator_id=actuator_id)
-
-        assert primary_status == idl.enums.MTM1M3.BumpTest.FAILED
         assert secondary_status == idl.enums.MTM1M3.BumpTest.FAILED
 
     async def test_stop_m1m3_bump_test_running(self) -> None:


### PR DESCRIPTION
Fixing OBS-708 - `m1m3/check_actuators.py` exits M1M3 engineering mode before the secondary test of the last actuator if the primary fails. This change causes `mtcs._wait_bump_test_ok` to wait for both tests to finish before raising a RuntimeError in the case one fails.