### PR TITLE
Use the Hexapod.moveInStepsInSteps

### DIFF
--- a/doc/news/OSW-271.feature.rst
+++ b/doc/news/OSW-271.feature.rst
@@ -1,0 +1,1 @@
+Use Hexapod.moveInSteps with the overwriteStepSizeFromConfig=True.

--- a/python/lsst/ts/observatory/control/maintel/mtcs.py
+++ b/python/lsst/ts/observatory/control/maintel/mtcs.py
@@ -2771,8 +2771,16 @@ class MTCS(BaseTCS):
                 "Camera Hexapod compensation mode enabled. Move with respect to LUT."
             )
 
-        await self.rem.mthexapod_1.cmd_move.set_start(
-            x=x, y=y, z=z, u=u, v=v, w=w, sync=sync, timeout=self.long_timeout
+        await self.rem.mthexapod_1.cmd_moveInSteps.set_start(
+            x=x,
+            y=y,
+            z=z,
+            u=u,
+            v=v,
+            w=w,
+            overwriteStepSizeFromConfig=True,
+            sync=sync,
+            timeout=self.long_timeout,
         )
 
         await self._handle_in_position(
@@ -2935,8 +2943,16 @@ class MTCS(BaseTCS):
                 "M2 Hexapod compensation mode enabled. Move with respect to LUT."
             )
 
-        await self.rem.mthexapod_2.cmd_move.set_start(
-            x=x, y=y, z=z, u=u, v=v, w=w, sync=sync, timeout=self.long_timeout
+        await self.rem.mthexapod_2.cmd_moveInSteps.set_start(
+            x=x,
+            y=y,
+            z=z,
+            u=u,
+            v=v,
+            w=w,
+            overwriteStepSizeFromConfig=True,
+            sync=sync,
+            timeout=self.long_timeout,
         )
 
         await self._handle_in_position(

--- a/python/lsst/ts/observatory/control/mock/mtcs_async_mock.py
+++ b/python/lsst/ts/observatory/control/mock/mtcs_async_mock.py
@@ -413,7 +413,7 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
             "evt_inPosition.aget.side_effect": self.mthexapod_1_evt_in_position,
             "evt_inPosition.next.side_effect": self.mthexapod_1_evt_in_position,
             "cmd_setCompensationMode.set_start.side_effect": self.mthexapod_1_cmd_set_compensation_mode,
-            "cmd_move.set_start.side_effect": self.mthexapod_1_cmd_move,
+            "cmd_moveInSteps.set_start.side_effect": self.mthexapod_1_cmd_move_in_steps,
             "cmd_offset.set_start.side_effect": self.mthexapod_1_cmd_offset,
         }
 
@@ -430,7 +430,7 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
             "evt_inPosition.aget.side_effect": self.mthexapod_2_evt_in_position,
             "evt_inPosition.next.side_effect": self.mthexapod_2_evt_in_position,
             "cmd_setCompensationMode.set_start.side_effect": self.mthexapod_2_cmd_set_compensation_mode,
-            "cmd_move.set_start.side_effect": self.mthexapod_2_cmd_move,
+            "cmd_moveInSteps.set_start.side_effect": self.mthexapod_2_cmd_move_in_steps,
             "cmd_offset.set_start.side_effect": self.mthexapod_2_cmd_offset,
         }
 
@@ -1200,7 +1200,7 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
             await asyncio.sleep(self.heartbeat_time)
             self._mthexapod_2_evt_compensation_mode.enabled = True
 
-    async def mthexapod_1_cmd_move(
+    async def mthexapod_1_cmd_move_in_steps(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
         self.log.debug("Move camera hexapod...")
@@ -1210,7 +1210,7 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
         )
         await asyncio.sleep(self.short_process_time)
 
-    async def mthexapod_2_cmd_move(
+    async def mthexapod_2_cmd_move_in_steps(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
         await asyncio.sleep(self.heartbeat_time / 2.0)
@@ -1234,23 +1234,25 @@ class MTCSAsyncMock(RemoteGroupAsyncMock):
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
         self.log.info(f"{kwargs=}")
-        await self.mtcs.rem.mthexapod_1.cmd_move.set_start(
+        await self.mtcs.rem.mthexapod_1.cmd_moveInSteps.set_start(
             x=kwargs["data"].value[6],
             y=kwargs["data"].value[7],
             z=kwargs["data"].value[5],
             u=kwargs["data"].value[8],
             v=kwargs["data"].value[9],
             w=0,
+            overwriteStepSizeFromConfig=True,
             sync=True,
             timeout=kwargs["timeout"],
         )
-        await self.mtcs.rem.mthexapod_2.cmd_move.set_start(
+        await self.mtcs.rem.mthexapod_2.cmd_moveInSteps.set_start(
             x=kwargs["data"].value[1],
             y=kwargs["data"].value[2],
             z=kwargs["data"].value[0],
             u=kwargs["data"].value[3],
             v=kwargs["data"].value[4],
             w=0,
+            overwriteStepSizeFromConfig=True,
             sync=True,
             timeout=kwargs["timeout"],
         )

--- a/tests/maintel/test_mtcs.py
+++ b/tests/maintel/test_mtcs.py
@@ -2245,8 +2245,12 @@ class TestMTCS(MTCSAsyncMock):
                 == hexapod_positions[axis]
             )
 
-        self.mtcs.rem.mthexapod_1.cmd_move.set_start.assert_awaited_with(
-            **hexapod_positions, w=0.0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_1.cmd_moveInSteps.set_start.assert_awaited_with(
+            **hexapod_positions,
+            w=0.0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
 
         assert self._mthexapod_1_evt_in_position.inPosition
@@ -2271,8 +2275,12 @@ class TestMTCS(MTCSAsyncMock):
                 == hexapod_positions[axis]
             )
 
-        self.mtcs.rem.mthexapod_2.cmd_move.set_start.assert_awaited_with(
-            **hexapod_positions, w=0.0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_2.cmd_moveInSteps.set_start.assert_awaited_with(
+            **hexapod_positions,
+            w=0.0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
 
         assert self._mthexapod_2_evt_in_position.inPosition
@@ -2297,8 +2305,12 @@ class TestMTCS(MTCSAsyncMock):
                 == hexapod_positions[axis]
             )
 
-        self.mtcs.rem.mthexapod_1.cmd_move.set_start.assert_awaited_with(
-            **hexapod_positions, w=0.0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_1.cmd_moveInSteps.set_start.assert_awaited_with(
+            **hexapod_positions,
+            w=0.0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
 
         assert self._mthexapod_1_evt_in_position.inPosition
@@ -2321,8 +2333,12 @@ class TestMTCS(MTCSAsyncMock):
                 == hexapod_positions[axis]
             )
 
-        self.mtcs.rem.mthexapod_2.cmd_move.set_start.assert_awaited_with(
-            **hexapod_positions, w=0.0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_2.cmd_moveInSteps.set_start.assert_awaited_with(
+            **hexapod_positions,
+            w=0.0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
 
         assert self._mthexapod_2_evt_in_position.inPosition
@@ -2348,8 +2364,16 @@ class TestMTCS(MTCSAsyncMock):
             timeout=self.mtcs.fast_timeout
         )
         self.mtcs.rem.mthexapod_1.evt_inPosition.flush.assert_called()
-        self.mtcs.rem.mthexapod_1.cmd_move.set_start.assert_awaited_with(
-            x=0, y=0, z=0, u=0, v=0, w=0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_1.cmd_moveInSteps.set_start.assert_awaited_with(
+            x=0,
+            y=0,
+            z=0,
+            u=0,
+            v=0,
+            w=0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
         self.mtcs.rem.mthexapod_1.evt_inPosition.next.assert_awaited_with(
             timeout=self.mtcs.long_timeout, flush=False
@@ -2369,8 +2393,16 @@ class TestMTCS(MTCSAsyncMock):
             timeout=self.mtcs.fast_timeout
         )
         self.mtcs.rem.mthexapod_2.evt_inPosition.flush.assert_called()
-        self.mtcs.rem.mthexapod_2.cmd_move.set_start.assert_awaited_with(
-            x=0, y=0, z=0, u=0, v=0, w=0, sync=True, timeout=self.mtcs.long_timeout
+        self.mtcs.rem.mthexapod_2.cmd_moveInSteps.set_start.assert_awaited_with(
+            x=0,
+            y=0,
+            z=0,
+            u=0,
+            v=0,
+            w=0,
+            overwriteStepSizeFromConfig=True,
+            sync=True,
+            timeout=self.mtcs.long_timeout,
         )
         self.mtcs.rem.mthexapod_2.evt_inPosition.next.assert_awaited_with(
             timeout=self.mtcs.long_timeout, flush=False


### PR DESCRIPTION
Use `Hexapod.moveInSteps` with the `overwriteStepSizeFromConfig=True`.